### PR TITLE
Don't require devtoolset-11-toolchain on EL 8

### DIFF
--- a/rpm/xrdcl-pelican.spec
+++ b/rpm/xrdcl-pelican.spec
@@ -29,6 +29,8 @@ BuildRequires: gcc-c++
 BuildRequires: cmake
 %else
 BuildRequires: cmake3
+%endif
+%if 0%{?rhel} == 7
 BuildRequires: devtoolset-11-toolchain
 %endif
 BuildRequires: curl-devel


### PR DESCRIPTION
Fix the conditional BuildRequires so that devtoolset-11-toolchain is only brought in on EL 7, where it is used.