### PR TITLE
Support for the Pelican connection broker

### DIFF
--- a/src/CurlOps.hh
+++ b/src/CurlOps.hh
@@ -41,7 +41,7 @@ public:
     CurlOperation(XrdCl::ResponseHandler *handler, const std::string &url, uint16_t timeout,
         XrdCl::Log *log);
 
-    virtual ~CurlOperation() {}
+    virtual ~CurlOperation();
 
     CurlOperation(const CurlOperation &) = delete;
 
@@ -60,10 +60,24 @@ public:
 
     bool IsRedirect() const {return m_headers.GetStatusCode() >= 300 && m_headers.GetStatusCode() < 400;}
 
-    // If returns non-negative, the result is a FD that should be waited on after a failure.
+    // If returns non-negative, the result is a FD that should be waited on after a broker connection request.
     virtual int WaitSocket() {return m_broker ? m_broker->GetBrokerSock() : -1;}
     // Callback when the `WaitSocket` is active for read.
     virtual int WaitSocketCallback(std::string &err);
+
+    // Connection broker-related functionality.
+    // When the broker URL is set, the operation will use the connection broker to get a TCP socket
+    // to the remote server.  Note that we will try the operation initially without in case the curl
+    // handle has an existing socket it can reuse.  If reuse fails, then the operation is going to fail
+    // with CURLE_COULDNT_CONNECT and we will retry (once) to connect via the broker.  This is all
+    // done outside curl's open socket callback to ensure the event loop stays non-blocking.
+
+    // Returns the broker URL that will be utilized for connecting the socket for the curl operation.
+    const std::string &GetBrokerUrl() const {return m_broker_url;}
+    void SetBrokerUrl(const std::string &broker) {m_broker_url = broker;}
+    bool StartBroker(std::string &err); // Start the broker connection process.
+    bool GetTriedBoker() const {return m_tried_broker;} // Returns true if the connection broker has been tried.
+    void SetTriedBoker() {m_tried_broker = true;} // Note that the connection broker has been attempted.
 
 private:
     bool Header(const std::string &header);
@@ -72,6 +86,8 @@ private:
     uint16_t m_timeout{0};
     std::unique_ptr<BrokerRequest> m_broker;
     int m_broker_reverse_socket{-1};
+    std::string m_broker_url;
+    bool m_tried_broker{false};
 
     static curl_socket_t OpenSocketCallback(void *clientp, curlsocktype purpose, struct curl_sockaddr *address);
     static int SockOptCallback(void *clientp, curl_socket_t curlfd, curlsocktype purpose);

--- a/src/CurlUtil.hh
+++ b/src/CurlUtil.hh
@@ -50,6 +50,31 @@ std::pair<uint16_t, uint32_t> HTTPStatusConvert(unsigned status);
 // various Pelican configurations
 CURL *GetHandle(bool verbose);
 
+// Connect to the broker socket and start callback request.
+class BrokerRequest {
+public:
+    BrokerRequest(const std::string &url) : m_url(url) {}
+    ~BrokerRequest();
+
+    // Start a request to get a socket connection.
+    // Returns a socket FD to monitor for reads on success or -1 on failure.
+    // On failure, err is set to the error message.
+    int StartRequest(std::string &err);
+
+    // Finish the socket connection request.
+    // Should only be called when the resulting socket from StartRequest is
+    // ready for read.
+    // On success, returns a FD connected to the requested server.
+    // Returns -1 on failure and sets err to the error message.
+    int FinishRequest(std::string &err);
+
+    int GetBrokerSock() const {return m_req;}
+private:
+    const std::string m_url;
+    int m_req{-1};
+    int m_rev{-1};
+};
+
 class HeaderParser {
 public:
     HeaderParser() {}
@@ -70,7 +95,9 @@ public:
 
     std::string GetStatusMessage() const {return m_resp_message;}
 
-    std::string GetLocation() const {return m_location;}
+    const std::string &GetLocation() const {return m_location;}
+
+    const std::string &GetBroker() const {return m_broker;}
 
 private:
     static bool validHeaderByte(unsigned char c);
@@ -87,6 +114,7 @@ private:
     std::string m_resp_protocol;
     std::string m_resp_message;
     std::string m_location;
+    std::string m_broker;
 };
 
 /**

--- a/src/CurlUtil.hh
+++ b/src/CurlUtil.hh
@@ -53,7 +53,7 @@ CURL *GetHandle(bool verbose);
 // Connect to the broker socket and start callback request.
 class BrokerRequest {
 public:
-    BrokerRequest(const std::string &url) : m_url(url) {}
+    BrokerRequest(const std::string &url);
     ~BrokerRequest();
 
     // Start a request to get a socket connection.
@@ -70,11 +70,16 @@ public:
 
     int GetBrokerSock() const {return m_req;}
 private:
-    const std::string m_url;
+    std::string m_url;
+    std::string m_origin;
+    std::string m_prefix;
     int m_req{-1};
     int m_rev{-1};
 };
 
+// Parser for headers as emitted by libcurl.
+//
+// Records specific headers known to be used by the project but ignores others.
 class HeaderParser {
 public:
     HeaderParser() {}

--- a/src/CurlUtil.hh
+++ b/src/CurlUtil.hh
@@ -53,8 +53,9 @@ CURL *GetHandle(bool verbose);
 // Connect to the broker socket and start callback request.
 class BrokerRequest {
 public:
-    BrokerRequest(const std::string &url);
+    BrokerRequest(CURL *curl, const std::string &url);
     ~BrokerRequest();
+    BrokerRequest(const BrokerRequest&) = delete;
 
     // Start a request to get a socket connection.
     // Returns a socket FD to monitor for reads on success or -1 on failure.

--- a/src/FedInfo.cc
+++ b/src/FedInfo.cc
@@ -139,6 +139,9 @@ FederationFactory::GetInfo(const std::string &federation, std::string &err)
     curl_easy_setopt(handle, CURLOPT_FAILONERROR, 1L);
 
     auto result = LookupInfo(handle, federation, err);
+    if (!result || !result->IsValid()) {
+        m_log.Warning(kLogXrdClPelican, "Failed to lookup federation info at %s due to error: %s", federation.c_str(), err.c_str());
+    }
     std::lock_guard<std::mutex> lock(m_cache_mutex);
     m_info_cache[federation] = result;
     return result;
@@ -177,6 +180,8 @@ private:
 std::shared_ptr<FederationInfo>
 FederationFactory::LookupInfo(CURL *handle, const std::string &federation, std::string &err)
 {
+    m_log.Info(kLogXrdClPelican, "Looking up federation metadata for URL %s", federation.c_str());
+
     auto now = time(nullptr);
     std::shared_ptr<FederationInfo> result(new FederationInfo(now));
 

--- a/src/PelicanFactory.cc
+++ b/src/PelicanFactory.cc
@@ -77,6 +77,8 @@ PelicanFactory::PelicanFactory() {
         env->ImportString( "PelicanCertFile", "XRD_PELICANCERTFILE");
         env->PutString("PelicanCertDir", "");
         env->ImportString( "PelicanCertDir", "XRD_PELICANCERTDIR");
+        env->PutString("PelicanBrokerSocket", "");
+        env->ImportString("PelicanBrokerSocket", "XRD_PELICANBROKERSOCKET");
 
         m_log->SetTopicName(kLogXrdClPelican, "XrdClPelican");
         for (unsigned idx=0; idx<m_poll_threads; idx++) {

--- a/src/PelicanFile.cc
+++ b/src/PelicanFile.cc
@@ -53,7 +53,9 @@ File::Open(const std::string      &url,
         }
         auto &factory = FederationFactory::GetInstance(*m_logger);
         std::string err;
-        auto info = factory.GetInfo(pelican_url.GetHostName(), err);
+        std::stringstream ss;
+        ss << pelican_url.GetHostName() << ":" << pelican_url.GetPort();
+        auto info = factory.GetInfo(ss.str(), err);
         if (!info) {
             return XrdCl::XRootDStatus(XrdCl::stError, err);
         }

--- a/src/PelicanFile.cc
+++ b/src/PelicanFile.cc
@@ -137,6 +137,10 @@ File::Read(uint64_t                offset,
     m_logger->Debug(kLogXrdClPelican, "Read %s (%d bytes at offset %d with timeout %d)", url.c_str(), size, offset, timeout);
 
     std::unique_ptr<CurlReadOp> readOp(new CurlReadOp(handler, url, timeout, std::make_pair(offset, size), static_cast<char*>(buffer), m_logger));
+    std::string broker;
+    if (GetProperty("BrokerURL", broker) && !broker.empty()) {
+        readOp->SetBrokerUrl(broker);
+    }
     try {
         m_queue->Produce(std::move(readOp));
     } catch (...) {
@@ -167,6 +171,11 @@ File::PgRead(uint64_t                offset,
     m_logger->Debug(kLogXrdClPelican, "PgRead %s (%d bytes at offset %lld)", url.c_str(), size, offset);
 
     std::unique_ptr<CurlPgReadOp> readOp(new CurlPgReadOp(handler, url, timeout, std::make_pair(offset, size), static_cast<char*>(buffer), m_logger));
+    std::string broker;
+    if (GetProperty("BrokerURL", broker) && !broker.empty()) {
+        readOp->SetBrokerUrl(broker);
+    }
+
     try {
         m_queue->Produce(std::move(readOp));
     } catch (...) {

--- a/src/PelicanFilesystem.cc
+++ b/src/PelicanFilesystem.cc
@@ -52,7 +52,9 @@ Filesystem::Stat(const std::string      &path,
         }
         auto &factory = FederationFactory::GetInstance(*m_logger);
         std::string err;
-        auto info = factory.GetInfo(pelican_url.GetHostName(), err);
+        std::stringstream ss;
+        ss << pelican_url.GetHostName() << ":" << pelican_url.GetPort();
+        auto info = factory.GetInfo(ss.str(), err);
         if (!info) {
             return XrdCl::XRootDStatus(XrdCl::stError, err);
         }


### PR DESCRIPTION
This allows a parent process to configure a Unix domain socket where connected sockets can be passed.  The intent is the pelican process will take the request, do a connection reversal, and pass a connected socket to the origin back to the plugin.

The socket request is handled in the main handler loop and is non-blocking.