### PR TITLE
Add stress tests to unit test suite based on go-wrk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,11 +28,14 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+    - uses: actions/setup-go@v5
     - name: install deps
       run: |
         sudo curl -L https://xrootd.web.cern.ch/repo/RPM-GPG-KEY.txt -o /etc/apt/trusted.gpg.d/xrootd.asc
         sudo /bin/sh -c 'echo "deb https://xrootd.web.cern.ch/ubuntu noble stable" >> /etc/apt/sources.list.d/xrootd.list'
         sudo apt update && sudo apt-get install -y cmake libcurl4-openssl-dev libcurl4 pkg-config libssl-dev xrootd-server libxrootd-dev libxrootd-server-dev libgtest-dev
+
+        go install github.com/bbockelm/go-wrk@92dbe19
 
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         # Install xrootd from upstream repo, not from Ubuntu
         sudo curl -L https://xrootd.web.cern.ch/repo/RPM-GPG-KEY.txt -o /etc/apt/trusted.gpg.d/xrootd.asc
         sudo /bin/sh -c 'echo "deb https://xrootd.web.cern.ch/ubuntu noble stable" >> /etc/apt/sources.list.d/xrootd.list'
-        sudo apt update && sudo apt-get install -y cmake libcurl4-openssl-dev libcurl4 pkg-config libssl-dev xrootd-server libxrootd-dev libxrootd-server-dev libgtest-dev
+        sudo apt update && sudo apt-get install -y cmake libcurl4-openssl-dev libcurl4 pkg-config libssl-dev xrootd-server libxrootd-dev libxrootd-server-dev libgtest-dev xrootd-scitokens-plugins
 
         # Install pelican directly from GH
         curl -sL https://github.com/PelicanPlatform/pelican/releases/download/v7.10.11/pelican_7.10.11-1_amd64.deb > /tmp/pelican_7.10.11-1_amd64.deb && sudo dpkg -i /tmp/pelican_7.10.11-1_amd64.deb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
         # This is because pelican v7.10.x ignores the client plugin location env var so
         # the system-level one needs to be used for the GHA.  This can be removed when
         # v7.11.0 is released.
-        ln -s /home/runner/work/xrdcl-pelican/build/tests/basic/pelican-plugin.conf /etc/xrootd/client.plugins.d/pelican-plugin.conf
+        sudo ln -s /home/runner/work/xrdcl-pelican/build/tests/basic/pelican-plugin.conf /etc/xrootd/client.plugins.d/pelican-plugin.conf
 
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,10 +31,15 @@ jobs:
     - uses: actions/setup-go@v5
     - name: install deps
       run: |
+        # Install xrootd from upstream repo, not from Ubuntu
         sudo curl -L https://xrootd.web.cern.ch/repo/RPM-GPG-KEY.txt -o /etc/apt/trusted.gpg.d/xrootd.asc
         sudo /bin/sh -c 'echo "deb https://xrootd.web.cern.ch/ubuntu noble stable" >> /etc/apt/sources.list.d/xrootd.list'
         sudo apt update && sudo apt-get install -y cmake libcurl4-openssl-dev libcurl4 pkg-config libssl-dev xrootd-server libxrootd-dev libxrootd-server-dev libgtest-dev
 
+        # Install pelican directly from GH
+        curl -sL https://github.com/PelicanPlatform/pelican/releases/download/v7.10.11/pelican_7.10.11-1_amd64.deb > /tmp/pelican_7.10.11-1_amd64.deb && sudo dpkg -i /tmp/pelican_7.10.11-1_amd64.deb
+
+        # Install the load tester
         go install github.com/bbockelm/go-wrk@92dbe19
 
     - name: Create Build Environment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,12 @@ jobs:
         # Install the load tester
         go install github.com/bbockelm/go-wrk@92dbe19
 
+        # Hack: link the system-level client plugin location to the future unit test one.
+        # This is because pelican v7.10.x ignores the client plugin location env var so
+        # the system-level one needs to be used for the GHA.  This can be removed when
+        # v7.11.0 is released.
+        ln -s /home/runner/work/xrdcl-pelican/build/tests/basic/pelican-plugin.conf /etc/xrootd/client.plugins.d/pelican-plugin.conf
+
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,14 @@ find_package( Threads REQUIRED )
 option(ENABLE_TESTS "Enable unit tests" FALSE)
 if (ENABLE_TESTS)
   find_package(GTest REQUIRED)
+
+  # go-wrk is a simple HTTP load tester, useful for stress testing
+  # The unit test using go-wrk have a small feature improvement over
+  # upstream; try installing with:
+  #   $ go install github.com/bbockelm/go-wrk@92dbe19
+  #
+  find_program(GoWrk go-wrk HINTS "$ENV{HOME}/go/bin")
+
   enable_testing()
   set(BUILD_TESTS TRUE)
 else()

--- a/src/CurlUtil.hh
+++ b/src/CurlUtil.hh
@@ -20,10 +20,11 @@
 
 #include <condition_variable>
 #include <deque>
+#include <memory>
 #include <mutex>
+#include <string>
 #include <unordered_map>
 #include <vector>
-#include <memory>
 
 // Forward dec'ls
 typedef void CURL;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,3 +55,14 @@ set_tests_properties(XrdClPelican::basic::stress_test
     ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR}"
     ATTACHED_FILES_ON_FAIL "${BASIC_TEST_LOGS}"
 )
+
+if (GoWrk)
+  add_test(NAME XrdClPelican::basic::wrk_test
+    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/pelican-wrk-test.sh" basic)
+
+  set_tests_properties(XrdClPelican::basic::wrk_test
+    PROPERTIES
+      FIXTURES_REQUIRED XrdClPelican::basic
+      ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR};WRK_BIN=${GoWrk}"
+      ATTACHED_FILES_ON_FAIL "${BASIC_TEST_LOGS}")
+endif()

--- a/tests/pelican-setup.sh
+++ b/tests/pelican-setup.sh
@@ -96,6 +96,9 @@ Logging:
     Pss: debug
     Pfc: debug
     Scitokens: debug
+    Http: debug
+    Xrd: trace
+    Xrootd: trace
   Origin:
     Http: debug
 
@@ -180,6 +183,7 @@ while [ -z "$CACHE_URL" ]; do
     echo "Waiting for cache to start ($IDX seconds so far) ..."
   fi
   if [ $IDX -eq 50 ]; then
+    cat "$BINARY_DIR/tests/$TEST_NAME/pelican.log"
     echo "Cache failed to start - failing"
     exit 1
   fi

--- a/tests/pelican-setup.sh
+++ b/tests/pelican-setup.sh
@@ -49,6 +49,11 @@ cd "$RUNDIR"
 export XRD_PLUGINCONFDIR="$RUNDIR/client.plugins.d"
 mkdir -p "$XRD_PLUGINCONFDIR"
 
+# Hack for Pelican v7.10.x and GHA: $XRD_PLUGINCONFDIR is ignored until 7.11.0 and
+# only the system-level plugin directory can be used.  Try creating a symlink in a
+# well-known location so the GHA can symlink the system plugin.conf to it.
+ln -s "$XRD_PLUGINCONFDIR/pelican-plugin.conf" "$BINARY_DIR/tests/$TEST_NAME/pelican-plugin.conf"
+
 PLUGIN_SUFFIX=so
 if [ $(uname) = "Darwin" ]; then
   PLUGIN_SUFFIX=dylib

--- a/tests/pelican-stress-test.sh
+++ b/tests/pelican-stress-test.sh
@@ -19,7 +19,7 @@ if [ ! -f "$BINARY_DIR/tests/$TEST_NAME/setup.sh" ]; then
   echo "Test environment file $BINARY_DIR/tests/$TEST_NAME/setup.sh does not exist - cannot run test"
   exit 1
 fi
-source "$BINARY_DIR/tests/$TEST_NAME/setup.sh"
+. "$BINARY_DIR/tests/$TEST_NAME/setup.sh"
 
 PUBLIC_HASH=$(sha256sum "$PUBLIC_TEST_FILE" | awk '{print $1;}')
 echo "Reference file content hash: $PUBLIC_HASH"

--- a/tests/pelican-teardown.sh
+++ b/tests/pelican-teardown.sh
@@ -17,7 +17,7 @@ if [ ! -f "$BINARY_DIR/tests/$TEST_NAME/setup.sh" ]; then
   echo "Test environment file $BINARY_DIR/tests/$TEST_NAME/setup.sh does not exist - cannot run test"
   exit 1
 fi
-source "$BINARY_DIR/tests/$TEST_NAME/setup.sh"
+. "$BINARY_DIR/tests/$TEST_NAME/setup.sh"
 
 
 if [ -z "$PELICAN_PID" ]; then

--- a/tests/pelican-test.sh
+++ b/tests/pelican-test.sh
@@ -23,6 +23,8 @@ CONTENTS=$(curl --cacert "$X509_CA_FILE" -v -L --fail -H "@$HEADER_FILE" "$FEDER
 CURL_EXIT=$?
 
 if [ $CURL_EXIT -ne 0 ]; then
+  cat "$BINARY_DIR/tests/$TEST_NAME/pelican.log"
+  cat "$BINARY_DIR/tests/$TEST_NAME/client.log"
   echo "Download of hello-world text failed"
   exit 1
 fi

--- a/tests/pelican-test.sh
+++ b/tests/pelican-test.sh
@@ -17,7 +17,7 @@ if [ ! -f "$BINARY_DIR/tests/$TEST_NAME/setup.sh" ]; then
   echo "Test environment file $BINARY_DIR/tests/$TEST_NAME/setup.sh does not exist - cannot run test"
   exit 1
 fi
-source "$BINARY_DIR/tests/$TEST_NAME/setup.sh"
+. "$BINARY_DIR/tests/$TEST_NAME/setup.sh"
 
 CONTENTS=$(curl --cacert "$X509_CA_FILE" -v -L --fail -H "@$HEADER_FILE" "$FEDERATION_URL/test/hello_world.txt" 2>> "$BINARY_DIR/tests/$TEST_NAME/client.log")
 CURL_EXIT=$?

--- a/tests/pelican-wrk-test.sh
+++ b/tests/pelican-wrk-test.sh
@@ -19,7 +19,7 @@ if [ ! -f "$BINARY_DIR/tests/$TEST_NAME/setup.sh" ]; then
   echo "Test environment file $BINARY_DIR/tests/$TEST_NAME/setup.sh does not exist - cannot run test"
   exit 1
 fi
-source "$BINARY_DIR/tests/$TEST_NAME/setup.sh"
+. "$BINARY_DIR/tests/$TEST_NAME/setup.sh"
 
 set -x
 "$WRK_BIN" -c 10 -d 10 -no-vr "$CACHE_URL/test-public/hello_world.txt"

--- a/tests/pelican-wrk-test.sh
+++ b/tests/pelican-wrk-test.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+TEST_NAME=$1
+
+if [ -z "$BINARY_DIR" ]; then
+  echo "\$BINARY_DIR environment variable is not set; cannot run test"
+  exit 1
+fi
+if [ ! -d "$BINARY_DIR" ]; then
+  echo "$BINARY_DIR is not a directory; cannot run test"
+  exit 1
+fi
+
+echo "Running $TEST_NAME - concurrent downloads"
+
+echo > "$BINARY_DIR/tests/$TEST_NAME/client.log"
+
+if [ ! -f "$BINARY_DIR/tests/$TEST_NAME/setup.sh" ]; then
+  echo "Test environment file $BINARY_DIR/tests/$TEST_NAME/setup.sh does not exist - cannot run test"
+  exit 1
+fi
+source "$BINARY_DIR/tests/$TEST_NAME/setup.sh"
+
+set -x
+"$WRK_BIN" -c 10 -d 10 -no-vr "$CACHE_URL/test-public/hello_world.txt"
+"$WRK_BIN" -c 200 -d 10 -no-vr -T 10000 -f "$PLAYBACK_FILE"
+"$WRK_BIN" -c 200 -d 10 -no-vr -T 10000 -f "$PLAYBACK_FILE"
+"$WRK_BIN" -c 200 -d 10 -no-vr -T 10000 -f "$ORIGIN_PLAYBACK_FILE"
+
+#"$WRK_BIN" -c 10 -d 10 -no-vr "$CACHE_URL/test-public/hello_world-1.txt"
+
+#"$WRK_BIN" -c 200 -d 10 -no-vr "$CACHE_URL/test-public/hello_world-2.txt"
+#"$WRK_BIN" -c 200 -d 10 -no-vr "$CACHE_URL/test-public/hello_world.txt"
+


### PR DESCRIPTION
This pushes xrootd and was essential for revealing several bugs in the upstream code.