### PR TITLE
Implement directory listing for the cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         # Install xrootd from upstream repo, not from Ubuntu
         sudo curl -L https://xrootd.web.cern.ch/repo/RPM-GPG-KEY.txt -o /etc/apt/trusted.gpg.d/xrootd.asc
         sudo /bin/sh -c 'echo "deb https://xrootd.web.cern.ch/ubuntu noble stable" >> /etc/apt/sources.list.d/xrootd.list'
-        sudo apt update && sudo apt-get install -y cmake libcurl4-openssl-dev libcurl4 pkg-config libssl-dev xrootd-server libxrootd-dev libxrootd-server-dev libgtest-dev xrootd-scitokens-plugins
+        sudo apt update && sudo apt-get install -y cmake libcurl4-openssl-dev libcurl4 pkg-config libssl-dev xrootd-server xrootd-client libxrootd-dev libxrootd-server-dev libgtest-dev xrootd-scitokens-plugins
 
         # Install pelican directly from GH
         curl -sL https://github.com/PelicanPlatform/pelican/releases/download/v7.11.8/pelican_7.11.8-1_amd64.deb > /tmp/pelican_7.11.8-1_amd64.deb && sudo dpkg -i /tmp/pelican_7.11.8-1_amd64.deb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ public:
 int main(void) {return 0;}"
 HAVE_XRDCL_IFACE6)
 
-add_library(XrdClPelicanObj OBJECT src/CurlUtil.cc src/CurlUtil.hh src/CurlOps.cc src/CurlOps.hh src/PelicanFactory.cc src/PelicanFile.cc src/PelicanFile.hh src/PelicanFilesystem.cc src/PelicanFilesystem.hh src/FedInfo.cc src/FedInfo.hh src/ParseTimeout.cc src/ParseTimeout.hh src/DirectorCache.cc src/DirectorCache.hh)
+add_library(XrdClPelicanObj OBJECT src/CurlUtil.cc src/CurlUtil.hh src/CurlListdir.cc src/CurlOps.cc src/CurlOps.hh src/PelicanFactory.cc src/PelicanFile.cc src/PelicanFile.hh src/PelicanFilesystem.cc src/PelicanFilesystem.hh src/FedInfo.cc src/FedInfo.hh src/ParseTimeout.cc src/ParseTimeout.hh src/DirectorCache.cc src/DirectorCache.hh)
 target_include_directories(XrdClPelicanObj PRIVATE ${XRootD_INCLUDE_DIR})
 target_link_libraries(XrdClPelicanObj ${XRootD_UTILS_LIBRARIES} ${XRootD_CLIENT_LIBRARIES} CURL::libcurl tinyxml2::tinyxml2 Threads::Threads nlohmann_json::nlohmann_json)
 set_target_properties(XrdClPelicanObj PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/src/CurlListdir.cc
+++ b/src/CurlListdir.cc
@@ -1,0 +1,153 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "CurlOps.hh"
+#include "CurlUtil.hh"
+
+#include <XrdCl/XrdClLog.hh>
+#include <XrdCl/XrdClXRootDResponses.hh>
+
+#include <tinyxml2.h>
+
+using namespace Pelican;
+
+bool CurlListdirOp::ParseProp(DavEntry &entry, tinyxml2::XMLElement *prop)
+{
+    for (auto child = prop->FirstChildElement(); child != nullptr; child = child->NextSiblingElement()) {
+        if (!strcmp(child->Name(), "D:resourcetype") || !strcmp(child->Name(), "lp1:resourcetype")) {
+            auto collection = child->FirstChildElement("D:collection");
+            entry.m_isdir = collection != nullptr;
+        } else if (!strcmp(child->Name(), "D:getcontentlength") || !strcmp(child->Name(), "lp1:getcontentlength")) {
+            auto size = child->GetText();
+            if (size == nullptr) {
+                return false;
+            }
+            try {
+                entry.m_size = std::stoll(size);
+            } catch (std::invalid_argument &e) {
+                return false;
+            }
+        } else if (strcmp(child->Name(), "D:getlastmodified") == 0) {
+            auto lastmod = child->GetText();
+            if (lastmod == nullptr) {
+                return false;
+            }
+            struct tm tm;
+            if (strptime(lastmod, "%a, %d %b %Y %H:%M:%S %Z", &tm) == nullptr) {
+                return false;
+            }
+            entry.m_lastmodified = mktime(&tm);
+        } else if (strcmp(child->Name(), "D:href") == 0) {
+            auto href = child->GetText();
+            if (href == nullptr) {
+                return false;
+            }
+            entry.m_name = href;
+        }
+    }
+    return true;    
+}
+
+std::pair<CurlListdirOp::DavEntry, bool>
+CurlListdirOp::ParseResponse(tinyxml2::XMLElement *response)
+{
+    DavEntry entry;
+    bool success = false;
+    for (auto child = response->FirstChildElement(); child != nullptr; child = child->NextSiblingElement()) {
+        if (!strcmp(child->Name(), "D:href")) {
+            auto href = child->GetText();
+            if (href == nullptr) {
+                return {entry, false};
+            }
+            // NOTE: This is not particularly robust; it assumes that the server is only returning
+            // a depth of exactly one and is not using a trailing slash to indicate a directory.
+            std::string_view href_str(href);
+            auto last_slash = href_str.find_last_of('/');
+            if (last_slash != std::string_view::npos) {
+                entry.m_name = href_str.substr(last_slash + 1);
+            } else {
+                entry.m_name = href;
+            }
+            continue;
+        }
+        if (strcmp(child->Name(), "D:propstat")) {
+            continue;
+        }
+        for (auto propstat = child->FirstChildElement(); propstat != nullptr; propstat = propstat->NextSiblingElement()) {
+            if (strcmp(propstat->Name(), "D:prop")) {
+                continue;
+            }
+            success = ParseProp(entry, propstat);
+            if (!success) {
+                return {entry, success};
+            }
+        }
+    }
+    return {entry, success};
+}
+
+void
+CurlListdirOp::Success()
+{
+    SetDone();
+    m_logger->Debug(kLogXrdClPelican, "CurlListdirOp::Success");
+
+    std::unique_ptr<XrdCl::DirectoryList> dirlist(new XrdCl::DirectoryList());
+
+    tinyxml2::XMLDocument doc;
+    auto err = doc.Parse(m_response.c_str());
+    if (err != tinyxml2::XML_SUCCESS) {
+        m_logger->Error(kLogXrdClPelican, "Failed to parse XML response: %s", m_response.substr(0, 1024).c_str());
+        Fail(XrdCl::errErrorResponse, kXR_FSError, "Server responded to directory listing with invalid XML");
+        return;
+    }
+
+    auto elem = doc.RootElement();
+    if (strcmp(elem->Name(), "D:multistatus")) {
+        m_logger->Error(kLogXrdClPelican, "Unexpected XML response: %s", m_response.substr(0, 1024).c_str());
+        Fail(XrdCl::errErrorResponse, kXR_FSError, "Server responded to directory listing unexpected XML root");
+        return;
+    }
+    bool skip = true;
+    for (auto response = elem->FirstChildElement(); response != nullptr; response = response->NextSiblingElement()) {
+        if (strcmp(response->Name(), "D:response")) {
+            continue;
+        }
+
+        auto [entry, success] = ParseResponse(response);
+        if (!success) {
+            m_logger->Error(kLogXrdClPelican, "Failed to parse response element in XML response: %s", m_response.substr(0, 1024).c_str());
+            Fail(XrdCl::errErrorResponse, kXR_FSError, "Server responded with invalid directory listing");
+            return;
+        }
+        // Skip the first entry in the response, which is the directory itself
+        if (skip) {
+            skip = false;
+        } else {
+            dirlist->Add(new XrdCl::DirectoryList::ListEntry(m_host_addr, entry.m_name, new XrdCl::StatInfo("nobody", entry.m_size, XrdCl::StatInfo::Flags::IsReadable | (entry.m_isdir ? XrdCl::StatInfo::Flags::IsDir : 0), entry.m_lastmodified)));
+        }
+    }
+
+    m_logger->Debug(kLogXrdClPelican, "Successful propfind directory listing operation on %s (%u items)", m_url.c_str(), static_cast<unsigned>(dirlist->GetSize()));
+    if (m_handler == nullptr) {return;}
+    auto obj = new XrdCl::AnyObject();
+    obj->Set(dirlist.release());
+
+    m_handler->HandleResponse(new XrdCl::XRootDStatus(), obj);
+    m_handler = nullptr;
+}

--- a/src/PelicanFilesystem.hh
+++ b/src/PelicanFilesystem.hh
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -54,7 +54,7 @@ public:
     virtual XrdCl::XRootDStatus DirList(const std::string          &path,
                                         XrdCl::DirListFlags::Flags  flags,
                                         XrdCl::ResponseHandler     *handler,
-                                        timeout_t                   timeout ) override;
+                                        timeout_t                   timeout) override;
 
     virtual bool SetProperty(const std::string &name,
                              const std::string &value) override;
@@ -62,10 +62,17 @@ public:
     virtual bool GetProperty(const std::string &name,
                              std::string &value) const override;
 
+    virtual XrdCl::XRootDStatus Locate(const std::string        &path,
+                                       XrdCl::OpenFlags::Flags   flags,
+                                       XrdCl::ResponseHandler   *handler,
+                                       timeout_t                 timeout) override;
+
     // Get the header timeout value, taking into consideration the provided command timeout and XrdCl's default values
     struct timespec GetHeaderTimeout(time_t oper_timeout, const std::string &headerValue);
 
 private:
+    XrdCl::XRootDStatus ConstructURL(const std::string &oper, const std::string &path, timeout_t timeout, std::string &full_url, const DirectorCache *&dcache, bool &is_pelican, bool &is_cached, struct timespec &ts);
+
     std::unordered_map<std::string, std::string> properties_;
 
     std::shared_ptr<HandlerQueue> m_queue;

--- a/tests/pelican-setup.sh
+++ b/tests/pelican-setup.sh
@@ -160,7 +160,8 @@ echo "Hello, World" > "$PELICAN_PUBLIC_EXPORTDIR/hello_world.txt"
 
 mkdir "$PELICAN_PUBLIC_EXPORTDIR/subdir"
 touch "$PELICAN_PUBLIC_EXPORTDIR/subdir/test1"
-touch "$PELICAN_PUBLIC_EXPORTDIR/subdir/test2"
+echo 'Hello, world!' > "$PELICAN_PUBLIC_EXPORTDIR/subdir/test2"
+mkdir "$PELICAN_PUBLIC_EXPORTDIR/subdir/test3"
 
 dd if=/dev/urandom of="$PELICAN_PUBLIC_EXPORTDIR/hello_world-1mb.txt" count=$((4 * 1024)) bs=1024
 IDX=0


### PR DESCRIPTION
With this, the cache will proxy through requests for directory listings.

This is potentially quite useful as future clients wouldn't need to go straight to the origin for the directory listing.  Since the cache supports connection brokering, we could support recursive downloads even when the origin doesn't have a public IP.