### PR TITLE
Fixups for building v1.0.0 RPMs

### DIFF
--- a/rpm/xrdcl-pelican.spec
+++ b/rpm/xrdcl-pelican.spec
@@ -8,7 +8,7 @@ Group: System Environment/Daemons
 License: BSD
 URL: https://github.com/pelicanplatform/xrdcl-pelican
 # Generated from:
-# git archive v%{version} --prefix=xrdcl-pelican-%{version}/ | gzip -7 > ~/rpmbuild/SOURCES/xrdcl-pelican-%{version}.tar.gz
+# git archive v%%{version} --prefix=xrdcl-pelican-%%{version}/ | gzip -7 > ~/rpmbuild/SOURCES/xrdcl-pelican-%%{version}.tar.gz
 Source0: %{name}-%{version}.tar.gz
 
 %define xrootd_current_major 5
@@ -37,9 +37,12 @@ BuildRequires: devtoolset-11-toolchain
 %endif
 BuildRequires: curl-devel
 %{?systemd_requires}
-# For %{_unitdir} macro
+# For %%{_unitdir} macro
 BuildRequires: systemd
 BuildRequires: openssl-devel
+BuildRequires: tinyxml2-devel
+# nlohmann-json-devel is available from the OSG repos
+BuildRequires: nlohmann-json-devel
 
 Requires: xrootd-client >= 1:%{xrootd_current_major}.%{xrootd_current_minor}
 Requires: xrootd-client <  1:%{xrootd_next_major}.0.0-1
@@ -55,7 +58,7 @@ Requires: xrootd-client <  1:%{xrootd_next_major}.0.0-1
 . /opt/rh/devtoolset-11/enable
 %endif
 
-%cmake3 -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+%cmake3 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DXROOTD_EXTERNAL_TINYXML2=1 -DXROOTD_EXTERNAL_JSON=1 .
 make VERBOSE=1 %{?_smp_mflags}
 
 %install

--- a/src/CurlUtil.cc
+++ b/src/CurlUtil.cc
@@ -916,7 +916,7 @@ CurlWorker::Run() {
             std::string err;
             auto result = iter->second->WaitSocketCallback(err);
             if (result == -1) {
-                m_logger->Warning(kLogXrdClPelican, ("Error when invoking the broker callback: " + err).c_str());
+                m_logger->Warning(kLogXrdClPelican, "Error when invoking the broker callback: %s", err.c_str());
                 iter->second->Fail(XrdCl::errErrorResponse, 1, err);
                 m_op_map.erase(handle);
                 broker_reqs.erase(entry.fd);


### PR DESCRIPTION
- Add tinyxml2-devel and nlohmann-json-devel as dependencies instead of downloading them at build time
- Fix non-constant used as format string
- Get rid of "macro expanded in comment" warnings