### PR TITLE
Fix format string errors in PelicanFile.cc

### DIFF
--- a/src/PelicanFile.cc
+++ b/src/PelicanFile.cc
@@ -236,7 +236,7 @@ File::Read(uint64_t                offset,
     }
 
     auto ts = GetHeaderTimeout(timeout);
-    m_logger->Debug(kLogXrdClPelican, "Read %s (%d bytes at offset %d with timeout %d)", url.c_str(), size, offset, ts.tv_sec);
+    m_logger->Debug(kLogXrdClPelican, "Read %s (%d bytes at offset %ld with timeout %ld)", url.c_str(), size, offset, ts.tv_sec);
 
     std::unique_ptr<CurlReadOp> readOp(new CurlReadOp(handler, url, ts, std::make_pair(offset, size), static_cast<char*>(buffer), m_logger));
     std::string broker;
@@ -275,7 +275,7 @@ File::PgRead(uint64_t                offset,
     }
 
     auto ts = GetHeaderTimeout(timeout);
-    m_logger->Debug(kLogXrdClPelican, "PgRead %s (%d bytes at offset %lld)", url.c_str(), size, offset);
+    m_logger->Debug(kLogXrdClPelican, "PgRead %s (%d bytes at offset %ld)", url.c_str(), size, offset);
 
     std::unique_ptr<CurlPgReadOp> readOp(new CurlPgReadOp(handler, url, ts, std::make_pair(offset, size), static_cast<char*>(buffer), m_logger));
     std::string broker;


### PR DESCRIPTION
This fixes type differences between the format string and the parameters, which raises errors on EL9.