### PR TITLE
Permit tinyxml2 to come from a local tarball

### DIFF
--- a/cmake/tinyxml2/CMakeLists.txt
+++ b/cmake/tinyxml2/CMakeLists.txt
@@ -9,11 +9,15 @@ if( NOT EXISTS "${TINYXML2_URL}" )
 endif()
 cmake_policy(SET CMP0135 NEW)
 
-# 321ea883b7190d4e85cae5512a12e5eaa8f8731f is git tag v10.0.0
+# 3bdf15128ba16686e69bce256cc468e76c7b94ff2c7f391cc5ec09e40bff3839 is the GitHub source artifact
+# corresponding to git tag v10.0.0
+#
+# Note we override CMAKE_INSTALL_LIBDIR to force it to be `lib`; on RHEL platforms, it defaults
+# to lib64, messing up the CMAKE_PREFIX_PATH search for the cmake files.
 ExternalProject_Add(
     tinyxml2
     URL "${TINYXML2_URL}"
     URL_HASH SHA256=3bdf15128ba16686e69bce256cc468e76c7b94ff2c7f391cc5ec09e40bff3839
     TEST_COMMAND ""
-    CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>;-DCMAKE_POSITION_INDEPENDENT_CODE=ON" )
+    CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>;-DCMAKE_INSTALL_LIBDIR=lib;-DCMAKE_POSITION_INDEPENDENT_CODE=ON" )
 

--- a/cmake/tinyxml2/CMakeLists.txt
+++ b/cmake/tinyxml2/CMakeLists.txt
@@ -3,11 +3,17 @@ cmake_minimum_required( VERSION 3.16 )
 project(tinyxml2)
 
 include(ExternalProject)
+set( TINYXML2_URL "${CMAKE_CURRENT_SOURCE_DIR}/tinyxml2-10.0.0.tar.gz" )
+if( NOT EXISTS "${TINYXML2_URL}" )
+    set( TINYXML2_URL "https://github.com/leethomason/tinyxml2/archive/refs/tags/10.0.0.tar.gz" )
+endif()
+cmake_policy(SET CMP0135 NEW)
+
 # 321ea883b7190d4e85cae5512a12e5eaa8f8731f is git tag v10.0.0
 ExternalProject_Add(
     tinyxml2
-    GIT_REPOSITORY https://github.com/leethomason/tinyxml2.git
-    GIT_TAG 321ea883b7190d4e85cae5512a12e5eaa8f8731f
+    URL "${TINYXML2_URL}"
+    URL_HASH SHA256=3bdf15128ba16686e69bce256cc468e76c7b94ff2c7f391cc5ec09e40bff3839
     TEST_COMMAND ""
     CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>;-DCMAKE_POSITION_INDEPENDENT_CODE=ON" )
 


### PR DESCRIPTION
On the OSG Koji builder, the version of tinyxml2 available for EL8 is too old.  The `ExternalProject_Add` command with a HTTPS URL is not usable because Koji builds are not allowed access to the network to aid reproducability.

This allows the builder to drop the tinyxml2 tarball in the `cmake/tinyxml2` directory (particularly, it must be named `tinyxml2-10.0.0.tar.gz`) to have that used instead of a download.