### PR TITLE
Discover and use the cache authorization token

### DIFF
--- a/src/PelicanFactory.cc
+++ b/src/PelicanFactory.cc
@@ -94,6 +94,10 @@ PelicanFactory::PelicanFactory() {
         env->PutString("PelicanFederationMetadataTimeout", "");
         env->ImportString("PelicanFederationMetadataTimeout", "XRD_PELICANFEDERATIONMETADATATIMEOUT");
 
+        // The default location of the cache token
+        env->PutString("PelicanCacheTokenLocation", "");
+        env->ImportString("PelicanCacheTokenLocation", "XRD_PELICANCACHETOKENLOCATION");
+
         env->PutString("PelicanClientCertFile", "");
         env->ImportString("PelicanClientCertFile", "XRD_PELICANCLIENTCERTFILE");
         env->PutString("PelicanClientKeyFile", "");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,9 +5,9 @@ endif()
 
 include(GoogleTest)
 
-add_executable(xrdcl-pelican-test ParseTimeoutTest.cc DirectorCacheTest.cc HeaderParser.cc)
+add_executable(xrdcl-pelican-test ParseTimeoutTest.cc DirectorCacheTest.cc HeaderParser.cc CurlWorker.cc)
 target_link_libraries(xrdcl-pelican-test XrdClPelicanTesting GTest::GTest GTest::Main)
-target_include_directories(xrdcl-pelican-test PRIVATE ../src)
+target_include_directories(xrdcl-pelican-test PRIVATE ../src ${XRootD_INCLUDE_DIR})
 
 gtest_discover_tests(xrdcl-pelican-test)
 

--- a/tests/CurlWorker.cc
+++ b/tests/CurlWorker.cc
@@ -1,0 +1,144 @@
+/****************************************************************
+ *
+ * Copyright (C) 2024, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "CurlWorker.hh"
+
+#include <XrdCl/XrdClDefaultEnv.hh>
+#include <XrdCl/XrdClLog.hh>
+
+#include <gtest/gtest.h>
+
+#include <fcntl.h>
+
+#include <thread>
+
+class CurlWorkerFixture : public testing::Test {
+
+protected:
+    CurlWorkerFixture()
+      : m_log(XrdCl::DefaultEnv::GetLog())
+    {
+        std::call_once(m_init, []{
+            curl_global_init(CURL_GLOBAL_DEFAULT);
+        });
+    }
+
+    void SetUp() override {
+        char token_path[] = "xrdcl_pelican_test_token.XXXXXX";
+        ASSERT_NE(-1, mkstemp(token_path));
+        m_token_path = std::string(token_path);
+        m_curl = curl_easy_init();
+        ASSERT_NE(nullptr, m_curl);
+    }
+
+    void TearDown() override {
+        if (m_curl) {curl_easy_cleanup(m_curl);}
+        if (!m_token_path.empty()) {
+            ASSERT_NE(-1, unlink(m_token_path.c_str()));
+        }
+    }
+
+    void WriteTokenFile(const std::string &contents) const {
+        int fd;
+        fd = open(m_token_path.c_str(), O_TRUNC|O_WRONLY);
+        ASSERT_NE(-1, fd);
+
+        off_t offset = 0;
+        auto remaining = contents.length();
+        while (remaining) {
+            int rc = write(fd, contents.data() + offset, remaining);
+            if (rc == -1) {
+                if (errno == EAGAIN || errno == EINTR) {
+                    continue;
+                }
+                ASSERT_NE(-1, rc) << "Write failed with " << strerror(errno);
+            }
+            remaining -= static_cast<size_t>(rc);
+            offset += rc;
+        }
+        ASSERT_NE(-1, close(fd));
+    }
+
+    void CheckCurlUrl(const std::string &expected) const {
+        ASSERT_NE(nullptr, m_curl);
+        char *url_char{nullptr};
+        ASSERT_EQ(CURLE_OK, curl_easy_getinfo(m_curl, CURLINFO_EFFECTIVE_URL, &url_char));
+        ASSERT_NE(nullptr, url_char);
+        ASSERT_NE('\0', url_char[0]);
+        ASSERT_EQ(expected ,std::string(url_char));
+    }
+
+    XrdCl::Log *GetLog() const {return m_log;}
+    const std::string &GetTokenPath() const {return m_token_path;}
+    CURL *GetCurl() const {return m_curl;}
+
+private:
+    XrdCl::Log *m_log{nullptr};
+    std::string m_token_path;
+    CURL *m_curl{nullptr};
+    static std::once_flag m_init;
+};
+
+decltype(CurlWorkerFixture::m_init) CurlWorkerFixture::m_init;
+
+TEST_F(CurlWorkerFixture, RefreshToken) {
+    WriteTokenFile("REDACTED");
+
+    auto [success, contents] = Pelican::CurlWorker::RefreshCacheTokenStatic(GetTokenPath(), GetLog());
+    ASSERT_TRUE(success);
+    ASSERT_EQ("REDACTED", contents);
+
+    WriteTokenFile("\n#test\n\tfoo ");
+    std::tie(success, contents) = Pelican::CurlWorker::RefreshCacheTokenStatic(GetTokenPath(), GetLog());
+    ASSERT_TRUE(success);
+    ASSERT_EQ("foo", contents);
+
+    std::tie(success, contents) = Pelican::CurlWorker::RefreshCacheTokenStatic("", GetLog());
+    ASSERT_TRUE(success);
+
+    contents = "foo-test";
+    std::tie(success, contents) = Pelican::CurlWorker::RefreshCacheTokenStatic(GetTokenPath() + "DoesNotExist", GetLog());
+    ASSERT_FALSE(success);
+    ASSERT_EQ("", contents);
+
+    WriteTokenFile("");
+    std::tie(success, contents) = Pelican::CurlWorker::RefreshCacheTokenStatic(GetTokenPath(), GetLog());
+    ASSERT_TRUE(success);
+    ASSERT_EQ("", contents);
+
+    WriteTokenFile("foo\nbar");
+    std::tie(success, contents) = Pelican::CurlWorker::RefreshCacheTokenStatic(GetTokenPath(), GetLog());
+    ASSERT_TRUE(success);
+    ASSERT_EQ("bar", contents);
+}
+
+TEST_F(CurlWorkerFixture, CurlSetup) {
+    auto curl = GetCurl();
+
+    ASSERT_EQ(CURLE_OK, curl_easy_setopt(curl, CURLOPT_URL, "https://test.com"));
+    ASSERT_TRUE(Pelican::CurlWorker::SetupCacheTokenStatic("", curl, GetLog()));
+    CheckCurlUrl("https://test.com");
+
+    ASSERT_EQ(CURLE_OK, curl_easy_setopt(curl, CURLOPT_URL, "https://test.com"));
+    ASSERT_TRUE(Pelican::CurlWorker::SetupCacheTokenStatic("foo", curl, GetLog()));
+    CheckCurlUrl("https://test.com?access_token=foo");
+
+    ASSERT_EQ(CURLE_OK, curl_easy_setopt(curl, CURLOPT_URL, "https://test.com/prefix?test"));
+    ASSERT_TRUE(Pelican::CurlWorker::SetupCacheTokenStatic("foo", curl, GetLog()));
+    CheckCurlUrl("https://test.com/prefix?test&access_token=foo");
+}

--- a/tests/pelican-setup.sh
+++ b/tests/pelican-setup.sh
@@ -211,6 +211,10 @@ while [ -z "$CACHE_URL" ]; do
   if [ $IDX -gt 1 ]; then
     echo "Waiting for cache to start ($IDX seconds so far) ..."
   fi
+  if ! kill -0 "$PELICAN_PID" 2>/dev/null; then
+    echo "Pelican process crashed - failing"
+    exit 1
+  fi
   if [ $IDX -eq 50 ]; then
     cat "$BINARY_DIR/tests/$TEST_NAME/pelican.log"
     echo "Cache failed to start - failing"

--- a/tests/pelican-setup.sh
+++ b/tests/pelican-setup.sh
@@ -72,17 +72,6 @@ mkdir -p "$PELICAN_EXPORTDIR"
 PELICAN_PUBLIC_EXPORTDIR="$RUNDIR/pelican-export"
 mkdir -p "$PELICAN_PUBLIC_EXPORTDIR"
 
-if [ "$VALGRIND" -eq 1 ]; then
-  XROOTD_BIN=$(command -v xrootd)
-  mkdir -p "$RUNDIR/xrootd-wrapper"
-  cat > "$RUNDIR/xrootd-wrapper/xrootd" <<EOF
-#!/bin/sh
-exec valgrind "$XROOTD_BIN" "\$@"
-EOF
-  chmod +x "$RUNDIR/xrootd-wrapper/xrootd"
-  export PATH=$RUNDIR/xrootd-wrapper:$PATH
-fi
-
 # XRootD has strict length limits on the admin path location.
 # Therefore, we also create a directory in /tmp.
 XROOTD_RUNDIR=$(mktemp -d -p /tmp xrootd_test.XXXXXXXX)
@@ -170,7 +159,42 @@ while [ $IDX -ne 100 ]; do
   ln -s "$PELICAN_PUBLIC_EXPORTDIR/hello_world-1mb.txt" "$PELICAN_PUBLIC_EXPORTDIR/hello_world-$IDX.txt"
 done
 
-# Launch pelican & accompanying XRootD services.
+####################################################
+# Configure xrootd wrapper to have custom env vars #
+####################################################
+# Until Pelican has been updated to use XRD_PELICANCACHETOKENLOCATION, we inject
+# it via a wrapper script
+cat > "$RUNDIR/cache_token" << EOF
+# This is a token file
+# We set the token to 'REDACTED' to allow comparison before and after xrootd learns
+# how to redact the 'access_token' parameter
+
+  REDACTED  
+
+EOF
+
+XROOTD_BIN=$(command -v xrootd)
+if [ "$VALGRIND" -eq 1 ]; then
+  # Note we escape the quotes here -- when the contents of the
+  # variable are written to the generated shell script, we want the
+  # non-valgrind case to result in an empty string in the file
+  VALGRIND_BIN=\"$(command -v valgrind)\"
+fi
+
+BINDIR="$RUNDIR/bin"
+mkdir -p -- "$BINDIR"
+cat > "$BINDIR/xrootd" << EOF
+#!/bin/sh
+export XRD_PELICANCACHETOKENLOCATION="$RUNDIR/cache_token"
+set -x
+exec $VALGRIND_BIN "$XROOTD_BIN" "\$@"
+EOF
+chmod +x "$BINDIR/xrootd"
+export PATH="$BINDIR:$PATH"
+
+##################################################
+# Launch pelican & accompanying XRootD services. #
+##################################################
 "$PELICAN_BIN" --config "$PELICAN_CONFIG" serve -d --module origin,registry,director,cache 0<&- >"$BINARY_DIR/tests/$TEST_NAME/pelican.log" 2>&1 &
 PELICAN_PID=$!
 echo "Pelican PID: $PELICAN_PID"

--- a/tests/pelican-teardown.sh
+++ b/tests/pelican-teardown.sh
@@ -25,6 +25,10 @@ if [ -z "$PELICAN_PID" ]; then
   exit 1
 fi
 
+if ! kill -0 "$PELICAN_PID" 2>/dev/null; then
+  echo "Pelican process was already shut down by time the tear down was started"
+  exit
+fi
 kill "$PELICAN_PID"
 
 SHUTDOWN_MSG=$(grep -a "Pelican is safely exited" "$BINARY_DIR/tests/$TEST_NAME/pelican.log")

--- a/tests/pelican-test.sh
+++ b/tests/pelican-test.sh
@@ -91,3 +91,11 @@ assert egrep -q -e '-r-------- (.*) 0 (.*) /test-public/subdir/test1' "$BINARY_D
 assert egrep -q -e '-r-------- (.*) 14 (.*) /test-public/subdir/test2' "$BINARY_DIR/tests/$TEST_NAME/xrdfs.out"
 assert egrep -q -e 'dr-------- (.*) /test-public/subdir/test3' "$BINARY_DIR/tests/$TEST_NAME/xrdfs.out"
 assert_eq 3 "$(wc -l "$BINARY_DIR/tests/$TEST_NAME/xrdfs.out" | awk '{print $1}')"
+
+##
+# Ensure that the 'access_token' argument is being used with the cache token
+
+if ! grep -q 'http_Protocol:  Parsing first line: PROPFIND /test-public/subdir/test3?access_token=REDACTED HTTP/1.1" daemon=xrootd.origin' "$BINARY_DIR/tests/$TEST_NAME/pelican.log"; then
+  echo "access_token not specified in the xrootd origin log"
+  exit 1
+fi


### PR DESCRIPTION
If a cache authorization token file is provided in the plugin's configuration, then periodically read it out and use it in the generated curl requests.