### PR TITLE
Small improvements to the read error messages

### DIFF
--- a/src/CurlOps.cc
+++ b/src/CurlOps.cc
@@ -507,6 +507,23 @@ CurlReadOp::Setup(CURL *curl, CurlWorker &worker)
 }
 
 void
+CurlReadOp::Fail(uint16_t errCode, uint32_t errNum, const std::string &msg)
+{
+    std::string custom_msg = msg;
+    SetDone();
+    if (m_handler == nullptr) {return;}
+    if (!custom_msg.empty()) {
+        m_logger->Debug(kLogXrdClPelican, "curl operation at offset %llu failed with message: %s", static_cast<long long unsigned>(m_op.first), msg.c_str());
+        custom_msg += " (read operation at offset " + std::to_string(static_cast<long long unsigned>(m_op.first)) + ")";
+    } else {
+        m_logger->Debug(kLogXrdClPelican, "curl operation at offset %llu failed with status code %d", static_cast<long long unsigned>(m_op.first), errNum);
+    }
+    auto status = new XrdCl::XRootDStatus(XrdCl::stError, errCode, errNum, custom_msg);
+    m_handler->HandleResponse(status, nullptr);
+    m_handler = nullptr;
+}
+
+void
 CurlReadOp::Success()
 {
     SetDone();

--- a/src/CurlOps.hh
+++ b/src/CurlOps.hh
@@ -55,7 +55,7 @@ public:
 
     virtual void Setup(CURL *curl, CurlWorker &);
 
-    void Fail(uint16_t errCode, uint32_t errNum, const std::string &);
+    virtual void Fail(uint16_t errCode, uint32_t errNum, const std::string &);
 
     virtual void ReleaseHandle();
 
@@ -212,6 +212,7 @@ public:
     virtual ~CurlReadOp() {}
 
     void Setup(CURL *curl, CurlWorker &) override;
+    void Fail(uint16_t errCode, uint32_t errNum, const std::string &msg) override;
     void Success() override;
     void ReleaseHandle() override;
 

--- a/src/CurlUtil.cc
+++ b/src/CurlUtil.cc
@@ -1018,7 +1018,7 @@ CurlWorker::Run() {
 #ifdef HAVE_XPROTOCOL_TIMEREXPIRED
                         op->Fail(XrdCl::errOperationExpired, XErrorCode::kXR_TimerExpired, "Origin did not respond within timeout");
 #else
-                        op->Fail(XrdCl::errOperationExpired, ESTALE, "Origin did not respond within timeout");
+                        op->Fail(XrdCl::errOperationExpired, 0, "Origin did not respond within timeout");
 #endif
                     } else {
                         auto xrdCode = CurlCodeConvert(res);


### PR DESCRIPTION
Make the `Fail` function be a virtual and override it for the `Read` operation.  This includes the offset of the read in the error message with the intent of making it easier to correlate failures and requests in the logs.