### PR TITLE
Do not expire director cache entries on `Get`

### DIFF
--- a/src/DirectorCache.cc
+++ b/src/DirectorCache.cc
@@ -18,5 +18,35 @@
 
 #include "DirectorCache.hh"
 
+#include <thread>
+
 std::unordered_map<std::string, std::unique_ptr<Pelican::DirectorCache>> Pelican::DirectorCache::m_caches;
 std::shared_mutex Pelican::DirectorCache::m_caches_lock;
+std::once_flag Pelican::DirectorCache::m_expiry_launch;
+
+Pelican::DirectorCache::DirectorCache(const std::chrono::steady_clock::time_point &now) :
+    m_root{now}
+{
+    std::call_once(m_expiry_launch, [] {
+        std::thread t(DirectorCache::ExpireThread);
+        t.detach();
+    });
+}
+
+void Pelican::DirectorCache::ExpireThread()
+{
+    while (true) {
+        std::this_thread::sleep_for(std::chrono::seconds(5));
+        std::vector<DirectorCache*> dcache;
+        auto now = std::chrono::steady_clock::now();
+        {
+            std::unique_lock lock(m_caches_lock);
+            for (const auto &entry : m_caches) {
+                dcache.push_back(entry.second.get());
+            }
+        }
+        for (const auto &entry : dcache) {
+            entry->Expire(now);
+        }
+    }
+}


### PR DESCRIPTION
When `Get` is invoked, the director cache used to remove any expired entries it found.  Unfortunately, `Get` is invoked while holding a shared (read-only) mutex; the deletion could trigger a potential segfault.

Instead, simply ignore expired entries and launch a separate cleanup thread to expire things every 5 seconds.