### PR TITLE
Add support for writes and third-party copy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,15 +113,25 @@ public:
 int main(void) {return 0;}"
 HAVE_XRDCL_IFACE6)
 
-add_library(XrdClPelicanObj OBJECT src/CurlUtil.cc src/CurlUtil.hh src/CurlListdir.cc src/CurlOps.cc src/CurlOps.hh src/PelicanFactory.cc src/PelicanFile.cc src/PelicanFile.hh src/PelicanFilesystem.cc src/PelicanFilesystem.hh src/FedInfo.cc src/FedInfo.hh src/ParseTimeout.cc src/ParseTimeout.hh src/DirectorCache.cc src/DirectorCache.hh)
+add_library(XrdClPelicanObj OBJECT
+  src/CurlUtil.cc src/CurlUtil.hh
+  src/CurlListdir.cc
+  src/CurlOps.cc src/CurlOps.hh
+  src/PelicanFactory.cc src/PelicanFactory.hh
+  src/PelicanFile.cc src/PelicanFile.hh
+  src/PelicanFilesystem.cc src/PelicanFilesystem.hh
+  src/FedInfo.cc src/FedInfo.hh
+  src/ParseTimeout.cc src/ParseTimeout.hh
+  src/DirectorCache.cc src/DirectorCache.hh
+)
 target_include_directories(XrdClPelicanObj PRIVATE ${XRootD_INCLUDE_DIR})
 target_link_libraries(XrdClPelicanObj ${XRootD_UTILS_LIBRARIES} ${XRootD_CLIENT_LIBRARIES} CURL::libcurl tinyxml2::tinyxml2 Threads::Threads nlohmann_json::nlohmann_json)
 set_target_properties(XrdClPelicanObj PROPERTIES POSITION_INDEPENDENT_CODE ON)
 if (HAVE_XPROTOCOL_TIMEREXPIRED)
-  target_compile_definitions(XrdClPelicanObj PRIVATE HAVE_XPROTOCOL_TIMEREXPIRED)
+  target_compile_definitions(XrdClPelicanObj PUBLIC HAVE_XPROTOCOL_TIMEREXPIRED)
 endif()
 if (HAVE_XRDCL_IFACE6)
-  target_compile_definitions(XrdClPelicanObj PRIVATE HAVE_XRDCL_IFACE6)
+  target_compile_definitions(XrdClPelicanObj PUBLIC HAVE_XRDCL_IFACE6)
 endif()
 
 # The test executables cannot link against the normal library on Linux as we hide the exported symbols

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,22 @@ find_package( Threads REQUIRED )
 
 option( ENABLE_TESTS "Enable unit tests" FALSE )
 if( ENABLE_TESTS )
-  find_package( GTest REQUIRED )
+  if( NOT XROOTD_PLUGINS_EXTERNAL_GTEST )
+    include( FetchContent )
+    set( GTEST_URL "${CMAKE_CURRENT_SOURCE_DIR}/googletest-1.15.2.tar.gz" )
+    if( NOT EXISTS "${GTEST_URL}" )
+        set( GTEST_URL "https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz" )
+    endif()
+    cmake_policy(SET CMP0135 NEW)
+    FetchContent_Declare(GTest
+      URL "${GTEST_URL}"
+      URL_HASH SHA256=7b42b4d6ed48810c5362c265a17faebe90dc2373c885e5216439d37927f02926
+      TEST_COMMAND ""
+    )
+    FetchContent_MakeAvailable( GTest )
+  else()
+    find_package( GTest REQUIRED )
+  endif()
 
   # go-wrk is a simple HTTP load tester, useful for stress testing
   # The unit test using go-wrk have a small feature improvement over

--- a/src/CurlUtil.hh
+++ b/src/CurlUtil.hh
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -46,6 +46,12 @@ const uint64_t kLogXrdClPelican = 73172;
 bool HTTPStatusIsError(unsigned status);
 
 std::pair<uint16_t, uint32_t> HTTPStatusConvert(unsigned status);
+
+// Trim the left side of a string_view for space
+std::string_view ltrim_view(const std::string_view &input_view);
+
+// Trim the left and right side of a string_view of whitespace
+std::string_view trim_view(const std::string_view &input_view);
 
 // Returns a newly-created curl handle (no internal caching) with the
 // various Pelican configurations

--- a/src/CurlWorker.hh
+++ b/src/CurlWorker.hh
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -94,6 +94,12 @@ private:
     bool m_x509_all{false};
     std::chrono::steady_clock::time_point m_last_prefix_log;
     std::shared_ptr<HandlerQueue> m_queue;
+
+    // Queue for operations that can be unpaused.
+    // Paused operations occur when a PUT is started but cannot be continued
+    // because more data is needed from the caller.
+    std::shared_ptr<HandlerQueue> m_continue_queue;
+
     std::unordered_map<CURL*, std::unique_ptr<CurlOperation>> m_op_map;
     std::unordered_set<std::string> m_x509_prefixes;
     XrdCl::Log* m_logger;

--- a/src/PelicanFactory.hh
+++ b/src/PelicanFactory.hh
@@ -1,0 +1,55 @@
+
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include <XrdCl/XrdClPlugInInterface.hh>
+
+#include <mutex>
+
+namespace XrdCl {
+    class Log;
+}
+
+namespace Pelican {
+
+class CurlOperation;
+class CurlWorker;
+class HandlerQueue;
+
+class PelicanFactory final : public XrdCl::PlugInFactory {
+public:
+    PelicanFactory();
+    virtual ~PelicanFactory() {}
+    PelicanFactory(const PelicanFactory &) = delete;
+
+    virtual XrdCl::FilePlugIn *CreateFile(const std::string &url) override;
+    virtual XrdCl::FileSystemPlugIn *CreateFileSystem(const std::string &url) override;
+
+    void Produce(std::unique_ptr<CurlOperation> op);
+private:
+    void init();
+
+    static bool m_initialized;
+    static std::shared_ptr<HandlerQueue> m_queue;
+    static XrdCl::Log *m_log;
+    static std::vector<std::unique_ptr<CurlWorker>> m_workers;
+    const static unsigned m_poll_threads{3};
+    static std::once_flag m_init_once;
+};
+
+}

--- a/src/PelicanFile.hh
+++ b/src/PelicanFile.hh
@@ -1,6 +1,6 @@
 /***************************************************************
  *
- * Copyright (C) 2023, Pelican Project, Morgridge Institute for Research
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License.  You may
@@ -33,8 +33,8 @@ class Log;
 
 namespace Pelican {
 
+class CurlPutOp;
 class DirectorCache;
-
 class HandlerQueue;
 
 class File final : public XrdCl::FilePlugIn {
@@ -76,6 +76,17 @@ public:
                                        void                   *buffer,
                                        XrdCl::ResponseHandler *handler,
                                        timeout_t               timeout) override;
+
+    virtual XrdCl::XRootDStatus Write(uint64_t            offset,
+                                  uint32_t                size,
+                                  const void             *buffer,
+                                  XrdCl::ResponseHandler *handler,
+                                  timeout_t               timeout) override;
+
+    virtual XrdCl::XRootDStatus Write(uint64_t             offset,
+                                  XrdCl::Buffer          &&buffer,
+                                  XrdCl::ResponseHandler  *handler,
+                                  timeout_t                timeout) override;
 
     virtual bool IsOpen() const override;
 
@@ -152,6 +163,13 @@ private:
 
     // The federation metadata timeout.
     static struct timespec m_fed_timeout;
+
+    // An in-progress put operation.
+    // File does *not* own this pointer.
+    CurlPutOp *m_put_op{nullptr};
+
+    // Offset of the next write operation;
+    off_t m_offset{0};
 };
 
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,9 +5,19 @@ endif()
 
 include(GoogleTest)
 
+add_executable( xrdcl-transfer-test CopyTest.cc )
 add_executable(xrdcl-pelican-test ParseTimeoutTest.cc DirectorCacheTest.cc HeaderParser.cc CurlWorker.cc)
-target_link_libraries(xrdcl-pelican-test XrdClPelicanTesting GTest::GTest GTest::Main)
+target_link_libraries( xrdcl-transfer-test XrdClPelicanTesting GTest::gtest_main )
+target_link_libraries( xrdcl-pelican-test XrdClPelicanTesting GTest::gtest_main )
+target_include_directories( xrdcl-transfer-test PRIVATE ../src ${XRootD_INCLUDE_DIR} )
 target_include_directories(xrdcl-pelican-test PRIVATE ../src ${XRootD_INCLUDE_DIR})
+
+gtest_add_tests( TARGET xrdcl-transfer-test TEST_LIST TransferTests )
+set_tests_properties( ${TransferTests}
+  PROPERTIES
+    FIXTURES_REQUIRED XrdClPelican::basic
+    ENVIRONMENT "ENV_FILE=${CMAKE_BINARY_DIR}/tests/basic/setup.sh;XRD_PLUGINCONFDIR=${CMAKE_BINARY_DIR}/tests/basic/client.plugins.d"
+)
 
 gtest_discover_tests(xrdcl-pelican-test)
 
@@ -20,7 +30,7 @@ add_test(NAME XrdClPelican::basic::setup
 set_tests_properties(XrdClPelican::basic::setup
   PROPERTIES
     FIXTURES_SETUP XrdClPelican::basic
-    ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR};SOURCE_DIR=${CMAKE_SOURCE_DIR}"
+    ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR};SOURCE_DIR=${CMAKE_SOURCE_DIR};XROOTD_BINDIR=${XRootD_DATA_DIR}/../bin"
 )
 
 add_test(NAME XrdClPelican::basic::teardown

--- a/tests/CopyTest.cc
+++ b/tests/CopyTest.cc
@@ -1,0 +1,289 @@
+/****************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "CurlUtil.hh"
+#include "CurlWorker.hh"
+#include "PelicanFactory.hh"
+#include "PelicanFile.hh"
+
+#include <XrdCl/XrdClDefaultEnv.hh>
+#include <XrdCl/XrdClLog.hh>
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <mutex>
+
+namespace {
+
+class SyncResponseHandler: public XrdCl::ResponseHandler {
+public:
+    SyncResponseHandler() {}
+
+    virtual ~SyncResponseHandler() {}
+
+    virtual void HandleResponse( XrdCl::XRootDStatus *status, XrdCl::AnyObject *response ) {
+        std::unique_lock lock(m_mutex);
+        m_status.reset(status);
+        m_obj.reset(response);
+        m_cv.notify_one();
+    }
+
+    void Wait() {
+        std::unique_lock lock(m_mutex);
+        m_cv.wait(lock, [&]{return m_status.get() != nullptr;});
+    }
+
+    std::unique_ptr<XrdCl::XRootDStatus> Status() {
+        return std::move(m_status);
+    }
+
+private:
+    std::mutex m_mutex;
+    std::condition_variable m_cv;
+
+    std::unique_ptr<XrdCl::XRootDStatus> m_status;
+    std::unique_ptr<XrdCl::AnyObject> m_obj;
+};
+
+} // namespace
+
+class CurlCopyFixture : public testing::Test {
+
+protected:
+    CurlCopyFixture()
+      : m_log(XrdCl::DefaultEnv::GetLog())
+    {}
+
+    void SetUp() override;
+
+    // Helper function to write a file with a given pattern of contents.
+    //
+    // Useful for making large files with known contents that are varying from
+    // call-to-call (useful in detection of off-by-one errors).
+    // - `writeSize`: Total size of the uploaded object
+    // - `chunkByte`: Byte value of the first character in the file.
+    // - `chunkSize`: Number of bytes to repeat the first `chunkByte`.  Afterward,
+    //   the function will write `chunkByte + 1` for `chunkSize` characters and so on.
+    void WritePattern(const std::string &name, const off_t writeSize,
+                      const unsigned char chunkByte, const size_t chunkSize);
+
+    // Helper function to verify the contents of a given object..
+    //
+    // Useful for verifying the contents of an object created with `WritePattern`
+    // - `writeSize`: Total size of the uploaded object
+    // - `chunkByte`: Byte value of the first character in the file.
+    // - `chunkSize`: Number of bytes to repeat the first `chunkByte`.  Afterward,
+    //   the function will write `chunkByte + 1` for `chunkSize` characters and so on.
+    void VerifyContents(const std::string &name, const off_t writeSize,
+                        const unsigned char chunkByte, const size_t chunkSize);
+
+    const std::string &GetOriginURL() const {return m_origin_url;}
+    const std::string &GetReadToken() const {return m_read_token;}
+    const std::string &GetWriteToken() const {return m_write_token;}
+
+    // Factory object; creating one will initialize the worker threads
+    static std::unique_ptr<Pelican::PelicanFactory> m_factory;
+
+private:
+    void ReadTokenFromFile(const std::string &fname, std::string &token);
+
+    // Flag for initializing the global settings inherited from the text fixture.
+    static std::once_flag m_init;
+
+    // Log object to help debug test runs
+    XrdCl::Log *m_log{nullptr};
+
+    // Whether the test fixture globals were initialized
+    static bool m_initialized;
+
+    // Location of the read token file
+    static std::string m_read_token_location;
+
+    // Contents of the read token
+    static std::string m_read_token;
+
+    // Location of the write token file
+    static std::string m_write_token_location;
+
+    // Contents of the write token
+    static std::string m_write_token;
+
+    // Location of the custom CA file used by the test
+    static std::string m_ca_file;
+
+    // URL prefix to contact the origin
+    std::string m_origin_url;
+
+    void parseEnvFile(const std::string &fname);
+};
+
+std::once_flag CurlCopyFixture::m_init;
+bool CurlCopyFixture::m_initialized = false;
+std::string CurlCopyFixture::m_read_token_location;
+std::string CurlCopyFixture::m_read_token;
+std::string CurlCopyFixture::m_write_token_location;
+std::string CurlCopyFixture::m_write_token;
+std::string CurlCopyFixture::m_ca_file;
+std::unique_ptr<Pelican::PelicanFactory> CurlCopyFixture::m_factory;
+
+void
+CurlCopyFixture::ReadTokenFromFile(const std::string &fname, std::string &token)
+{
+    std::ifstream fh(fname);
+    ASSERT_TRUE(fh.is_open());
+    std::string line;
+    while (std::getline(fh, line)) {
+        auto contents = Pelican::trim_view(line);
+        if (contents.empty()) {continue;}
+        if (contents[0] == '#') {continue;}
+        token = contents;
+        return;
+    }
+    ASSERT_FALSE(fh.fail());
+    FAIL() << "No token found in file " << fname;
+}
+
+void
+CurlCopyFixture::SetUp()
+{
+    std::call_once(m_init, [&] {
+        ASSERT_EQ(curl_global_init(CURL_GLOBAL_DEFAULT), 0);
+        char *env_file = getenv("ENV_FILE");
+
+        ASSERT_NE(env_file, nullptr) << "$ENV_FILE environment variable "
+                                        "not set; required to run test; this variable is set "
+                                        "automatically when test is run via `ctest`.";
+        parseEnvFile(env_file);
+        m_factory.reset(new Pelican::PelicanFactory());
+        m_initialized = true;
+    });
+    ASSERT_TRUE(m_initialized) << "Environment initialization failed";
+}
+
+void
+CurlCopyFixture::WritePattern(const std::string &name, const off_t writeSize,
+                                          const unsigned char chunkByte, const size_t chunkSize)
+{
+    XrdCl::File fh;
+
+    auto url = name + "?authz=" + GetWriteToken();
+    auto rv = fh.Open(url, XrdCl::OpenFlags::Write, XrdCl::Access::Mode(0755), static_cast<Pelican::File::timeout_t>(0));
+    ASSERT_TRUE(rv.IsOK()) << "Failed to open " << name << " for write: " << rv.ToString();
+
+    size_t sizeToWrite = (static_cast<off_t>(chunkSize) >= writeSize)
+                                                        ? static_cast<size_t>(writeSize)
+                                                        : chunkSize;
+    off_t curWriteSize = writeSize;
+    auto curChunkByte = chunkByte;
+    off_t offset = 0;
+    while (sizeToWrite) {
+        std::string writeBuffer(sizeToWrite, curChunkByte);
+
+        rv = fh.Write(offset, sizeToWrite, writeBuffer.data(), static_cast<Pelican::File::timeout_t>(0));
+        ASSERT_TRUE(rv.IsOK()) << "Failed to write " << name << ": " << rv.ToString();
+        
+        curWriteSize -= sizeToWrite;
+        offset += sizeToWrite;
+        sizeToWrite = (static_cast<off_t>(chunkSize) >= curWriteSize)
+                                            ? static_cast<size_t>(curWriteSize)
+                                            : chunkSize;
+        curChunkByte += 1;
+    }
+
+    rv = fh.Close();
+    ASSERT_TRUE(rv.IsOK());
+
+    VerifyContents(name, writeSize, chunkByte, chunkSize);
+}
+
+void
+CurlCopyFixture::VerifyContents(const std::string &obj,
+                                off_t expectedSize, unsigned char chunkByte,
+                                size_t chunkSize) {
+    XrdCl::File fh;
+
+    auto url = obj + "?authz=" + GetReadToken();
+    auto rv = fh.Open(url, XrdCl::OpenFlags::Read, XrdCl::Access::Mode(0755), static_cast<Pelican::File::timeout_t>(0));
+    ASSERT_TRUE(rv.IsOK());
+        
+    size_t sizeToRead = (static_cast<off_t>(chunkSize) >= expectedSize)
+                                                    ? expectedSize
+                                                    : chunkSize;
+    unsigned char curChunkByte = chunkByte;
+    off_t offset = 0;
+    while (sizeToRead) {
+        std::string readBuffer(sizeToRead, curChunkByte - 1);
+        uint32_t bytesRead;
+        rv = fh.Read(offset, sizeToRead, readBuffer.data(), bytesRead, static_cast<Pelican::File::timeout_t>(0));
+        ASSERT_TRUE(rv.IsOK());
+        ASSERT_EQ(bytesRead, sizeToRead);
+        readBuffer.resize(sizeToRead);
+
+        std::string correctBuffer(sizeToRead, curChunkByte);
+        ASSERT_EQ(readBuffer, correctBuffer);
+
+        expectedSize -= sizeToRead;
+        offset += sizeToRead;
+        sizeToRead = (static_cast<off_t>(chunkSize) >= expectedSize)
+                                            ? expectedSize
+                                            : chunkSize;
+        curChunkByte += 1;
+    }
+
+    rv = fh.Close();
+    ASSERT_TRUE(rv.IsOK());
+}
+
+void
+CurlCopyFixture::parseEnvFile(const std::string &fname) {
+    std::ifstream fh(fname);
+    if (!fh.is_open()) {
+        std::cerr << "Failed to open env file: " << strerror(errno);
+        exit(1);
+    }
+    std::string line;
+    while (std::getline(fh, line)) {
+        auto idx = line.find("=");
+        if (idx == std::string::npos) {
+            continue;
+        }
+        auto key = line.substr(0, idx);
+        auto val = line.substr(idx + 1);
+        if (key == "X509_CA_FILE") {
+            m_ca_file = val;
+            setenv("X509_CERT_FILE", m_ca_file.c_str(), 1);
+        } else if (key == "ORIGIN_URL") {
+            m_origin_url = val;
+        } else if (key == "WRITE_TOKEN") {
+            m_write_token_location = val;
+            ReadTokenFromFile(m_write_token_location, m_write_token);
+        } else if (key == "READ_TOKEN") {
+            m_read_token_location = val;
+            ReadTokenFromFile(m_read_token_location, m_read_token);
+        } else if (key == "XRD_PLUGINCONFDIR") {
+            setenv("XRD_PLUGINCONFDIR", val.c_str(), 1);
+        }
+    }
+}
+
+TEST_F(CurlCopyFixture, Test)
+{
+    auto source_url = GetOriginURL() + "/test/source_file";
+    WritePattern(source_url, 2*1024, 'a', 1023);
+}


### PR DESCRIPTION
As an experiment to make the plugin a bit more general purpose, this adds the ability to write data via the plugin (resulting in an HTTP PUT) and a COPY client.

Given there's no plugin interface for third-party-copy, that's exposed directly; will work with upstream XRootD on how to best invoke this.