### PR TITLE
Initialize sun_family field in sockaddr_un struct

### DIFF
--- a/src/CurlUtil.cc
+++ b/src/CurlUtil.cc
@@ -1218,6 +1218,7 @@ BrokerRequest::StartRequest(std::string &err)
     }
 
     struct sockaddr_un addr_un;
+    addr_un.sun_family = AF_UNIX;
     struct sockaddr *addr = reinterpret_cast<struct sockaddr *>(&addr_un);
     if (brokersocket.size() >= sizeof(addr_un.sun_path)) {
         err = "Location of broker socket (" + brokersocket + ") longer than maximum socket path name";


### PR DESCRIPTION
Initialized the `sun_family` field in the `sockaddr_un` struct with `AF_UNIX`. If this is not initialized, a garbage value is used, resulting in an `Invalid argument` error when connect is called.