### PR TITLE
Don't look for `prefix` param in broker URL

### DIFF
--- a/src/CurlUtil.cc
+++ b/src/CurlUtil.cc
@@ -1181,11 +1181,6 @@ BrokerRequest::BrokerRequest(CURL *curl, const std::string &url) {
         return;
     }
     m_origin = UrlDecode(curl, iter->second);
-    iter = pmap.find("prefix");
-    if (iter == pmap.end()) {
-        return;
-    }
-    m_prefix = UrlDecode(curl, iter->second);
     pmap.clear();
     xrd_url.SetParams(pmap);
     m_url = xrd_url.GetURL();
@@ -1245,7 +1240,6 @@ BrokerRequest::StartRequest(std::string &err)
     nlohmann::json jobj;
     jobj["broker_url"] = m_url;
     jobj["origin"] = m_origin;
-    jobj["prefix"] = m_prefix;
     std::string msg_val = jobj.dump() + "\n";
     if (send(sock, msg_val.c_str(), msg_val.size(), 0) == -1) {
         err = "Failed to send request to broker socket: " + std::string(strerror(errno));

--- a/src/CurlUtil.hh
+++ b/src/CurlUtil.hh
@@ -74,7 +74,6 @@ public:
 private:
     std::string m_url;
     std::string m_origin;
-    std::string m_prefix;
     int m_req{-1};
     int m_rev{-1};
 };


### PR DESCRIPTION
We were previously looking for the `prefix` param in the broker URL set in the `x-pelican-broker` header. This param was then sent to the cache Go process to connect to the origin through the broker. However, this is no longer required. All communication channels are now origin-host specific and no longer tied to the prefix.