### PR TITLE
Fix race and logic conditions in the write paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         git clone --depth=1 --branch v5.8.0-pelican https://github.com/PelicanPlatform/xrootd.git
         mkdir -p xrootd/build/release_dir
         cd xrootd/build
-        cmake .. -DENABLE_ASAN=true -DCMAKE_INSTALL_PREFIX=$PWD/release_dir
+        cmake .. -DCMAKE_INSTALL_PREFIX=$PWD/release_dir
         make -j $(($(nproc) + 2)) install
 
         # Install the load tester
@@ -51,7 +51,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: CMAKE_PREFIX_PATH=$PWD/../xrootd/build/release_dir/lib/cmake/XRootD cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_TESTS=true -DENABLE_ASAN=true
+      run: CMAKE_PREFIX_PATH=$PWD/../xrootd/build/release_dir/lib/cmake/XRootD cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_TESTS=true
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         git clone --depth=1 --branch v5.8.0-pelican https://github.com/PelicanPlatform/xrootd.git
         mkdir -p xrootd/build/release_dir
         cd xrootd/build
-        cmake .. -DCMAKE_INSTALL_PREFIX=$PWD/release_dir
+        cmake .. -DENABLE_ASAN=true -DCMAKE_INSTALL_PREFIX=$PWD/release_dir
         make -j $(($(nproc) + 2)) install
 
         # Install the load tester
@@ -51,7 +51,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: CMAKE_PREFIX_PATH=$PWD/../xrootd/build/release_dir/lib/cmake/XRootD cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_TESTS=true
+      run: CMAKE_PREFIX_PATH=$PWD/../xrootd/build/release_dir/lib/cmake/XRootD cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_TESTS=true -DENABLE_ASAN=true
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/src/CurlChecksum.cc
+++ b/src/CurlChecksum.cc
@@ -72,7 +72,7 @@ CurlChecksumOp::ReleaseHandle()
 void
 CurlChecksumOp::Success()
 {
-    SetDone();
+    SetDone(false);
     auto checksums = m_headers.GetChecksums();
 
     ChecksumCache::Instance().Put(m_url, checksums, std::chrono::steady_clock::now());

--- a/src/CurlChecksum.cc
+++ b/src/CurlChecksum.cc
@@ -87,7 +87,9 @@ CurlChecksumOp::Success()
         std::tie(type, value, isset) = checksums.GetFirst();
         if (!isset) {
             m_logger->Error(kLogXrdClPelican, "Checksums not found in response for %s", m_url.c_str());
-            m_handler->HandleResponse(new XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errCheckSumError), nullptr);
+            auto handle = m_handler;
+            m_handler = nullptr;
+            handle->HandleResponse(new XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errCheckSumError), nullptr);
             return; 
         }
     }
@@ -103,7 +105,8 @@ CurlChecksumOp::Success()
     auto obj = new XrdCl::AnyObject();
     obj->Set(buf);
 
-    m_handler->HandleResponse(new XrdCl::XRootDStatus(), obj);
+    auto handle = m_handler;
     m_handler = nullptr;
+    handle->HandleResponse(new XrdCl::XRootDStatus(), obj);
     // Does not call CurlStatOp::Success() as we don't need to invoke a stat info callback
 }

--- a/src/CurlListdir.cc
+++ b/src/CurlListdir.cc
@@ -163,6 +163,7 @@ CurlListdirOp::Success()
     auto obj = new XrdCl::AnyObject();
     obj->Set(dirlist.release());
 
-    m_handler->HandleResponse(new XrdCl::XRootDStatus(), obj);
+    auto handle = m_handler;
     m_handler = nullptr;
+    handle->HandleResponse(new XrdCl::XRootDStatus(), obj);
 }

--- a/src/CurlListdir.cc
+++ b/src/CurlListdir.cc
@@ -112,7 +112,7 @@ CurlListdirOp::ParseResponse(tinyxml2::XMLElement *response)
 void
 CurlListdirOp::Success()
 {
-    SetDone();
+    SetDone(false);
     m_logger->Debug(kLogXrdClPelican, "CurlListdirOp::Success");
 
     std::unique_ptr<XrdCl::DirectoryList> dirlist(new XrdCl::DirectoryList());

--- a/src/CurlOps.cc
+++ b/src/CurlOps.cc
@@ -718,7 +718,10 @@ void
 CurlPutOp::Pause()
 {
     SetDone(false);
-    if (m_handler == nullptr) {return;}
+    if (m_handler == nullptr) {
+        m_logger->Warning(kLogXrdClPelican, "Put operation paused with no callback handler");
+        return;
+    }
     auto handle = m_handler;
     auto status = new XrdCl::XRootDStatus();
     auto obj = new XrdCl::AnyObject();
@@ -734,7 +737,10 @@ void
 CurlPutOp::Success()
 {
     SetDone(false);
-    if (m_handler == nullptr) {return;}
+    if (m_handler == nullptr) {
+        m_logger->Warning(kLogXrdClPelican, "Put operation succeeded with no callback handler");
+        return;
+    }
     auto status = new XrdCl::XRootDStatus();
     auto obj = new XrdCl::AnyObject();
     auto handle = m_handler;

--- a/src/CurlOps.cc
+++ b/src/CurlOps.cc
@@ -55,7 +55,7 @@ CurlOperation::~CurlOperation() {
 void
 CurlOperation::Fail(uint16_t errCode, uint32_t errNum, const std::string &msg)
 {
-    SetDone();
+    SetDone(true);
     if (m_handler == nullptr) {return;}
     if (!msg.empty()) {
         m_logger->Debug(kLogXrdClPelican, "curl operation failed with message: %s", msg.c_str());
@@ -412,7 +412,7 @@ CurlStatOp::GetStatInfo() {
 void
 CurlStatOp::Success()
 {
-    SetDone();
+    SetDone(false);
     m_logger->Debug(kLogXrdClPelican, "CurlStatOp::Success");
     auto [size, isdir] = GetStatInfo();
     if (size < 0) {
@@ -467,7 +467,7 @@ CurlOpenOp::ReleaseHandle()
 void
 CurlOpenOp::Success()
 {
-    SetDone();
+    SetDone(false);
     char *url = nullptr;
     curl_easy_getinfo(m_curl.get(), CURLINFO_EFFECTIVE_URL, &url);
     if (url && m_file) {
@@ -567,7 +567,7 @@ CurlCopyOp::Setup(CURL *curl, CurlWorker &worker)
 void
 CurlCopyOp::Success()
 {
-    SetDone();
+    SetDone(false);
     if (m_handler == nullptr) {return;}
     auto status = new XrdCl::XRootDStatus();
     auto obj = new XrdCl::AnyObject();
@@ -714,7 +714,7 @@ CurlPutOp::ReleaseHandle()
 void
 CurlPutOp::Pause()
 {
-    SetDone();
+    SetDone(false);
     if (m_handler == nullptr) {return;}
     auto status = new XrdCl::XRootDStatus();
     auto obj = new XrdCl::AnyObject();
@@ -726,7 +726,7 @@ CurlPutOp::Pause()
 void
 CurlPutOp::Success()
 {
-    SetDone();
+    SetDone(false);
     if (m_handler == nullptr) {return;}
     auto status = new XrdCl::XRootDStatus();
     auto obj = new XrdCl::AnyObject();

--- a/src/CurlOps.cc
+++ b/src/CurlOps.cc
@@ -749,8 +749,12 @@ CurlPutOp::ContinueHandle()
 		return false;
 	}
 
-	curl_easy_pause(m_curl_handle, CURLPAUSE_CONT);
-	return true;
+	CURLcode rc;
+	if ((rc = curl_easy_pause(m_curl_handle, CURLPAUSE_CONT)) != CURLE_OK) {
+		m_logger->Error(kLogXrdClPelican, "Failed to continue a paused handle: %s", curl_easy_strerror(rc));
+		return false;
+	}
+	return m_curl_handle;
 }
 
 bool

--- a/src/CurlOps.hh
+++ b/src/CurlOps.hh
@@ -207,6 +207,14 @@ public:
     std::pair<int64_t, bool> GetStatInfo();
 
 protected:
+    // Mark the operation as a success and, as requested, return the stat info back
+    // to the object handler.
+    //
+    // Returning the info is optional as the CurlOpenOp derives from this clasa and
+    // if stat info is returned from an open without being requested then the
+    // object is leaked
+    void SuccessImpl(bool returnObj);
+
     // Returns whether the URL for the stat operation was originally for a pelican director
     bool IsPelican() const {return m_is_pelican;}
 

--- a/src/CurlOps.hh
+++ b/src/CurlOps.hh
@@ -129,6 +129,10 @@ public:
 
     // Return true if the transfer is done
     bool IsDone() const {return m_done;}
+
+    // Returns true if the operation has been marked as failed.
+    bool HasFailed() const {return m_has_failed;}
+
     // Client X509 status; returns true if the director requested X509 client auth be used.
     bool UseX509Auth() const {return m_x509_auth;}
 
@@ -152,6 +156,7 @@ private:
     bool m_tried_broker{false};
     bool m_received_header{false};
     bool m_done{false};
+    bool m_has_failed{false};
     bool m_x509_auth{false};
     int m_broker_reverse_socket{-1};
  
@@ -175,7 +180,7 @@ private:
 
 
 protected:
-    void SetDone() {m_done = true;}
+    void SetDone(bool has_failed) {m_done = true; m_has_failed = has_failed;}
     const std::string m_url;
     XrdCl::ResponseHandler *m_handler{nullptr};
     std::unique_ptr<CURL, void(*)(CURL *)> m_curl;

--- a/src/CurlOps.hh
+++ b/src/CurlOps.hh
@@ -478,9 +478,13 @@ public:
 		m_continue_queue = queue;
 	}
 
-    // Start continuation of a previously-started operation with additional data
-    bool Continue(XrdCl::ResponseHandler *handler, const char *buffer, size_t buffer_size);
-    bool Continue(XrdCl::ResponseHandler *handler, XrdCl::Buffer &&buffer);
+    // Start continuation of a previously-started operation with additional data.
+    //
+    // Since the CurlPutOp itself is kept as a reference-counted pointer by the
+    // Pelican::File handle, we need to pass a shared pointer to the continue queue.
+    // Hence the awkward interface of needing to be provided a shared pointer to oneself.
+    bool Continue(std::shared_ptr<CurlOperation> op, XrdCl::ResponseHandler *handler, const char *buffer, size_t buffer_size);
+    bool Continue(std::shared_ptr<CurlOperation> op, XrdCl::ResponseHandler *handler, XrdCl::Buffer &&buffer);
 
     // Pause the put operation; indicates the current buffer was sent successfully
     // but the operation is not yet complete.

--- a/src/CurlOps.hh
+++ b/src/CurlOps.hh
@@ -69,7 +69,7 @@ public:
     // Pauses occur when a PUT request has started but is waiting on more data
     // from the client; when additional data has arrived, the operation will
     // be continued and this function called by the worker thread.
-	virtual bool ContinueHandle() {return false;}
+	virtual bool ContinueHandle() {return true;}
 
     // Set the continue queue to use for when a paused handle is ready to
     // be re-run.

--- a/src/CurlRead.cc
+++ b/src/CurlRead.cc
@@ -64,8 +64,9 @@ CurlReadOp::Fail(uint16_t errCode, uint32_t errNum, const std::string &msg)
         m_logger->Debug(kLogXrdClPelican, "curl operation at offset %llu failed with status code %d", static_cast<long long unsigned>(m_op.first), errNum);
     }
     auto status = new XrdCl::XRootDStatus(XrdCl::stError, errCode, errNum, custom_msg);
-    m_handler->HandleResponse(status, nullptr);
+    auto handle = m_handler;
     m_handler = nullptr;
+    handle->HandleResponse(status, nullptr);
 }
 
 void
@@ -77,8 +78,9 @@ CurlReadOp::Success()
     auto chunk_info = new XrdCl::ChunkInfo(m_op.first, m_written, m_buffer);
     auto obj = new XrdCl::AnyObject();
     obj->Set(chunk_info);
-    m_handler->HandleResponse(status, obj);
+    auto handle = m_handler;
     m_handler = nullptr;
+    handle->HandleResponse(status, obj);
 }
 
 void
@@ -148,6 +150,7 @@ CurlPgReadOp::Success()
     auto page_info = new XrdCl::PageInfo(m_op.first, m_written, m_buffer, std::move(cksums));
     auto obj = new XrdCl::AnyObject();
     obj->Set(page_info);
-    m_handler->HandleResponse(status, obj);
+    auto handle = m_handler;
     m_handler = nullptr;
+    handle->HandleResponse(status, obj);
 }

--- a/src/CurlRead.cc
+++ b/src/CurlRead.cc
@@ -55,7 +55,7 @@ void
 CurlReadOp::Fail(uint16_t errCode, uint32_t errNum, const std::string &msg)
 {
     std::string custom_msg = msg;
-    SetDone();
+    SetDone(true);
     if (m_handler == nullptr) {return;}
     if (!custom_msg.empty()) {
         m_logger->Debug(kLogXrdClPelican, "curl operation at offset %llu failed with message: %s", static_cast<long long unsigned>(m_op.first), msg.c_str());
@@ -71,7 +71,7 @@ CurlReadOp::Fail(uint16_t errCode, uint32_t errNum, const std::string &msg)
 void
 CurlReadOp::Success()
 {
-    SetDone();
+    SetDone(false);
     if (m_handler == nullptr) {return;}
     auto status = new XrdCl::XRootDStatus();
     auto chunk_info = new XrdCl::ChunkInfo(m_op.first, m_written, m_buffer);
@@ -125,7 +125,7 @@ CurlReadOp::Write(char *buffer, size_t length)
 void                
 CurlPgReadOp::Success()
 {               
-    SetDone();
+    SetDone(false);
     if (m_handler == nullptr) {return;}
     auto status = new XrdCl::XRootDStatus();
 

--- a/src/CurlReadV.cc
+++ b/src/CurlReadV.cc
@@ -75,8 +75,9 @@ CurlVectorReadOp::Fail(uint16_t errCode, uint32_t errNum, const std::string &msg
         m_logger->Debug(kLogXrdClPelican, "curl vector operation starting at offset %s / length %s failed with status code %d", offset.c_str(), length.c_str(), errNum);
     }
     auto status = new XrdCl::XRootDStatus(XrdCl::stError, errCode, errNum, custom_msg);
-    m_handler->HandleResponse(status, nullptr);
+    auto handle = m_handler;
     m_handler = nullptr;
+    handle->HandleResponse(status, nullptr);
 }
 
 void
@@ -96,8 +97,9 @@ CurlVectorReadOp::Success()
     m_vr->SetSize(m_bytes_consumed);
     auto obj = new XrdCl::AnyObject();
     obj->Set(m_vr.release());
-    m_handler->HandleResponse(status, obj);
+    auto handle = m_handler;
     m_handler = nullptr;
+    handle->HandleResponse(status, obj);
 }
 
 void

--- a/src/CurlReadV.cc
+++ b/src/CurlReadV.cc
@@ -60,7 +60,7 @@ void
 CurlVectorReadOp::Fail(uint16_t errCode, uint32_t errNum, const std::string &msg)
 {
     std::string custom_msg = msg;
-    SetDone();
+    SetDone(true);
     if (m_handler == nullptr) {return;}
     std::string offset = "(unknown)";
     std::string length = "(unknown)";
@@ -82,7 +82,7 @@ CurlVectorReadOp::Fail(uint16_t errCode, uint32_t errNum, const std::string &msg
 void
 CurlVectorReadOp::Success()
 {
-    SetDone();
+    SetDone(false);
     if (m_handler == nullptr) {return;}
 
     // If there's a partial last response, give it to the client.

--- a/src/CurlUtil.hh
+++ b/src/CurlUtil.hh
@@ -201,10 +201,10 @@ class HandlerQueue {
 public:
     HandlerQueue();
 
-    void Produce(std::unique_ptr<CurlOperation> handler);
+    void Produce(std::shared_ptr<CurlOperation> handler);
 
-    std::unique_ptr<CurlOperation> Consume();
-    std::unique_ptr<CurlOperation> TryConsume();
+    std::shared_ptr<CurlOperation> Consume();
+    std::shared_ptr<CurlOperation> TryConsume();
 
     int PollFD() const {return m_read_fd;}
 
@@ -212,7 +212,7 @@ public:
     void RecycleHandle(CURL *);
 
 private:
-    std::deque<std::unique_ptr<CurlOperation>> m_ops;
+    std::deque<std::shared_ptr<CurlOperation>> m_ops;
     thread_local static std::vector<CURL*> m_handles;
     std::condition_variable m_consumer_cv;
     std::condition_variable m_producer_cv;

--- a/src/CurlWorker.hh
+++ b/src/CurlWorker.hh
@@ -100,7 +100,7 @@ private:
     // because more data is needed from the caller.
     std::shared_ptr<HandlerQueue> m_continue_queue;
 
-    std::unordered_map<CURL*, std::unique_ptr<CurlOperation>> m_op_map;
+    std::unordered_map<CURL*, std::shared_ptr<CurlOperation>> m_op_map;
     std::unordered_set<std::string> m_x509_prefixes;
     XrdCl::Log* m_logger;
     std::string m_x509_client_cert_file;

--- a/src/PelicanFile.cc
+++ b/src/PelicanFile.cc
@@ -151,8 +151,7 @@ File::Open(const std::string      &url,
 
     if (skipStat) {
         m_is_opened = true;
-        auto obj = new XrdCl::AnyObject();
-        handler->HandleResponse(new XrdCl::XRootDStatus(), obj);
+        handler->HandleResponse(new XrdCl::XRootDStatus(), nullptr);
         return XrdCl::XRootDStatus();
     }
 

--- a/src/PelicanFile.cc
+++ b/src/PelicanFile.cc
@@ -159,7 +159,7 @@ File::Open(const std::string      &url,
     auto ts = GetHeaderTimeout(timeout);
     m_logger->Debug(kLogXrdClPelican, "Opening %s (with timeout %d)", m_url.c_str(), timeout);
 
-    std::unique_ptr<CurlOpenOp> openOp(new CurlOpenOp(handler, m_url, ts, m_logger, this, m_dcache));
+    std::shared_ptr<CurlOpenOp> openOp(new CurlOpenOp(handler, m_url, ts, m_logger, this, m_dcache));
     try {
         m_queue->Produce(std::move(openOp));
     } catch (...) {
@@ -184,7 +184,7 @@ File::Close(XrdCl::ResponseHandler *handler,
     if (m_put_op) {
         m_logger->Debug(kLogXrdClPelican, "Flushing final write buffer on close");
         try {
-            m_put_op->Continue(handler, nullptr, 0);
+            m_put_op->Continue(m_put_op, handler, nullptr, 0);
             return XrdCl::XRootDStatus();
         } catch (...) {
             m_logger->Error(kLogXrdClPelican, "Cannot close - sending final buffer");
@@ -257,7 +257,7 @@ File::Read(uint64_t                offset,
     auto ts = GetHeaderTimeout(timeout);
     m_logger->Debug(kLogXrdClPelican, "Read %s (%d bytes at offset %lld with timeout %lld)", url.c_str(), size, static_cast<long long>(offset), static_cast<long long>(ts.tv_sec));
 
-    std::unique_ptr<CurlReadOp> readOp(new CurlReadOp(handler, url, ts, std::make_pair(offset, size), static_cast<char*>(buffer), m_logger));
+    std::shared_ptr<CurlReadOp> readOp(new CurlReadOp(handler, url, ts, std::make_pair(offset, size), static_cast<char*>(buffer), m_logger));
     std::string broker;
     if (GetProperty("BrokerURL", broker) && !broker.empty()) {
         readOp->SetBrokerUrl(broker);
@@ -306,7 +306,7 @@ File::VectorRead(const XrdCl::ChunkList &chunks,
     auto ts = GetHeaderTimeout(timeout);
     m_logger->Debug(kLogXrdClPelican, "Read %s (%lld chunks; first chunk is %u bytes at offset %lld with timeout %lld)", url.c_str(), static_cast<long long>(chunks.size()), static_cast<unsigned>(chunks[0].GetLength()), static_cast<long long>(chunks[0].GetOffset()), static_cast<long long>(ts.tv_sec));
 
-    auto readOp = std::make_unique<CurlVectorReadOp>(handler, url, ts, chunks, m_logger);
+    std::shared_ptr<CurlVectorReadOp> readOp(new CurlVectorReadOp(handler, url, ts, chunks, m_logger));
     std::string broker;
     if (GetProperty("BrokerURL", broker) && !broker.empty()) {
         readOp->SetBrokerUrl(broker);
@@ -350,11 +350,9 @@ File::Write(uint64_t                offset,
             m_logger->Warning(kLogXrdClPelican, "Cannot start PUT operation at non-zero offset");
             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidArgs, 0, "HTTP uploads must start at offset 0");
         }
-        auto put_op = std::make_unique<CurlPutOp>(handler, url, static_cast<const char*>(buffer), size, ts, m_logger);
-        m_put_op = put_op.get();
-
+        m_put_op.reset(new CurlPutOp(handler, url, static_cast<const char*>(buffer), size, ts, m_logger));
         try {
-            m_queue->Produce(std::move(put_op));
+            m_queue->Produce(m_put_op);
         } catch (...) {
             m_logger->Warning(kLogXrdClPelican, "Failed to add put op to queue");
             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errOSError);
@@ -370,7 +368,7 @@ File::Write(uint64_t                offset,
     }
     m_offset += size;
     try {
-        m_put_op->Continue(handler, static_cast<const char *>(buffer), size);
+        m_put_op->Continue(m_put_op, handler, static_cast<const char *>(buffer), size);
     } catch (...) {
         m_logger->Warning(kLogXrdClPelican, "Failed to add put op to continuation queue");
         return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errOSError);
@@ -401,11 +399,10 @@ File::Write(uint64_t                offset,
         if (offset != 0) {
             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidArgs, 0, "HTTP uploads must start at offset 0");
         }
-        auto put_op = std::make_unique<CurlPutOp>(handler, url, std::move(buffer), ts, m_logger);
-        m_put_op = put_op.get();
+        m_put_op.reset(new CurlPutOp(handler, url, std::move(buffer), ts, m_logger));
 
         try {
-            m_queue->Produce(std::move(put_op));
+            m_queue->Produce(m_put_op);
         } catch (...) {
             m_logger->Warning(kLogXrdClPelican, "Failed to add put op to queue");
             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errOSError);
@@ -421,7 +418,7 @@ File::Write(uint64_t                offset,
     }
     m_offset += buffer.GetSize();
     try {
-        m_put_op->Continue(handler, std::move(buffer));
+        m_put_op->Continue(m_put_op, handler, std::move(buffer));
     } catch (...) {
         m_logger->Warning(kLogXrdClPelican, "Failed to add put op to continuation queue");
         return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errOSError);
@@ -449,7 +446,7 @@ File::PgRead(uint64_t                offset,
     auto ts = GetHeaderTimeout(timeout);
     m_logger->Debug(kLogXrdClPelican, "PgRead %s (%d bytes at offset %lld)", url.c_str(), size, static_cast<long long>(offset));
 
-    std::unique_ptr<CurlPgReadOp> readOp(new CurlPgReadOp(handler, url, ts, std::make_pair(offset, size), static_cast<char*>(buffer), m_logger));
+    std::shared_ptr<CurlPgReadOp> readOp(new CurlPgReadOp(handler, url, ts, std::make_pair(offset, size), static_cast<char*>(buffer), m_logger));
     std::string broker;
     if (GetProperty("BrokerURL", broker) && !broker.empty()) {
         readOp->SetBrokerUrl(broker);

--- a/src/PelicanFile.hh
+++ b/src/PelicanFile.hh
@@ -170,8 +170,11 @@ private:
     static struct timespec m_fed_timeout;
 
     // An in-progress put operation.
-    // File does *not* own this pointer.
-    CurlPutOp *m_put_op{nullptr};
+    //
+    // This shared pointer is also copied to the queue and kept
+    // by the curl worker thread.  We will need to refer to the
+    // operation later to continue the write.
+    std::shared_ptr<CurlPutOp> m_put_op;
 
     // Offset of the next write operation;
     off_t m_offset{0};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ endif()
 
 include(GoogleTest)
 
-add_executable( xrdcl-transfer-test ChecksumTest.cc CopyTest.cc TransferTest.cc VectorReadTest.cc )
+add_executable( xrdcl-transfer-test ChecksumTest.cc CopyTest.cc TransferTest.cc VectorReadTest.cc WriteTest.cc )
 add_executable( xrdcl-pelican-test ParseTimeoutTest.cc DirectorCacheTest.cc HeaderParser.cc CurlWorker.cc ChecksumCache.cc )
 target_link_libraries( xrdcl-transfer-test XrdClPelicanTesting GTest::gtest_main )
 target_link_libraries( xrdcl-pelican-test XrdClPelicanTesting GTest::gtest_main )

--- a/tests/ChecksumTest.cc
+++ b/tests/ChecksumTest.cc
@@ -91,7 +91,7 @@ TEST_F(ChecksumFixture, Basic)
     // query string by the parameter `cks.type`.
     //
     // The expected response is the checksum type followed by the checksum value.
-    auto fs = m_factory->CreateFileSystem(GetOriginURL());
+    std::unique_ptr<XrdCl::FileSystemPlugIn> fs(m_factory->CreateFileSystem(GetOriginURL()));
     XrdCl::Buffer buffer;
     buffer.FromString(source_url + "?cks.type=md5&authz=" + GetReadToken());
     SyncResponseHandler srh;

--- a/tests/VectorReadTest.cc
+++ b/tests/VectorReadTest.cc
@@ -51,6 +51,7 @@ TEST_F(CurlVectorFixture, Test)
     rv = fh.VectorRead(chunks, nullptr, vrInfo, static_cast<Pelican::File::timeout_t>(10));
     ASSERT_TRUE(rv.IsOK());
     ASSERT_NE(vrInfo, nullptr);
+    std::unique_ptr<XrdCl::VectorReadInfo> vrInfoPtr(vrInfo);
 
     ASSERT_EQ(vrInfo->GetSize(), 6);
     ASSERT_EQ(vrInfo->GetChunks().size(), 3);

--- a/tests/WriteTest.cc
+++ b/tests/WriteTest.cc
@@ -1,0 +1,66 @@
+/****************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "CurlOps.hh"
+#include "PelicanFile.hh"
+#include "TransferTest.hh"
+
+#include <XrdCl/XrdClDefaultEnv.hh>
+#include <XrdCl/XrdClLog.hh>
+
+#include <gtest/gtest.h>
+
+class CurlWriteFixture : public TransferFixture {
+public:
+
+// Write 300 files in serial of differing size and contents.
+//
+// Goal is to find any bugs that don't require heavy concurrency to trigger
+// Count of files selected to keep the test run quick (5s on a test laptop)
+void InvokeMultipleWrites(const std::string &prefix, size_t size_count, size_t chunk_count) {
+    for (unsigned size_ctr = 1; size_ctr <= size_count; size_ctr ++) {
+        for (unsigned chunk_ctr = 1; chunk_ctr <= chunk_count; chunk_ctr ++) {
+            auto url = GetOriginURL() + "/test/write_" + prefix + "_" + std::to_string(size_ctr) + "_" + std::to_string(chunk_ctr);
+            ASSERT_NO_FATAL_FAILURE(WritePattern(url, chunk_ctr * 100'000, 'a', chunk_ctr * 10'000));
+        }
+    }
+}
+};
+
+// Write 300 files in serial of differing size and contents.
+//
+// Goal is to find any bugs that don't require heavy concurrency to trigger
+// Count of files selected to keep the test run quick (5s on a test laptop)
+TEST_F(CurlWriteFixture, SerialTest)
+{
+    ASSERT_NO_FATAL_FAILURE(InvokeMultipleWrites("serial", 30, 10));
+}
+
+// Write 100 files per thread in 10 threads
+//
+// Goal is to trigger concurrency-related write bugs.
+TEST_F(CurlWriteFixture, ParallelTest)
+{
+    std::vector<std::thread> threads;
+    for (unsigned ctr=0; ctr<10; ctr++) {
+        threads.emplace_back(&CurlWriteFixture::InvokeMultipleWrites, this, "parallel_" + std::to_string(ctr), 10, 10);
+    }
+    for (unsigned ctr=0; ctr<10; ctr++) {
+        threads[ctr].join();
+    }
+}

--- a/tests/pelican-setup.sh
+++ b/tests/pelican-setup.sh
@@ -206,6 +206,9 @@ mkdir -p -- "$BINDIR"
 cat > "$BINDIR/xrootd" << EOF
 #!/bin/sh
 export XRD_PELICANCACHETOKENLOCATION="$RUNDIR/cache_token"
+# ODR violations are disabled as XRootD currently has some, preventing
+# it from starting up.  See: https://github.com/xrootd/xrootd/issues/2471
+export ASAN_OPTIONS=detect_odr_violation=0
 export LD_LIBRARY_PATH="${XROOTD_LIBDIR}:$LD_LIBRARY_PATH"
 set -x
 exec $VALGRIND_BIN "$XROOTD_BIN" "\$@"

--- a/tests/pelican-stress-test.sh
+++ b/tests/pelican-stress-test.sh
@@ -11,6 +11,12 @@ if [ ! -d "$BINARY_DIR" ]; then
   exit 1
 fi
 
+CURL_BIN=$(command -v curl)
+if [ -z "$CURL_BIN" ]; then
+  echo "curl is not installed; required for test"
+  exit 1
+fi
+
 echo "Running $TEST_NAME - concurrent downloads"
 
 echo > "$BINARY_DIR/tests/$TEST_NAME/client.log"

--- a/tests/pelican-test.sh
+++ b/tests/pelican-test.sh
@@ -23,6 +23,12 @@ if [ ! -d "$BINARY_DIR" ]; then
   exit 1
 fi
 
+CURL_BIN=$(command -v curl)
+if [ -z "$CURL_BIN" ]; then
+  echo "curl is not installed; required for test"
+  exit 1
+fi
+
 XRDFS_BIN="$XROOTD_BINDIR/xrdfs"
 if [ -z "$XRDFS_BIN" ]; then
   echo "$XRDFS_BIN is not present; cannot run test"
@@ -115,6 +121,8 @@ export X509_CERT_FILE=$X509_CA_FILE
 export BEARER_TOKEN_FILE
 chmod 0600 "$BEARER_TOKEN_FILE"
 export LD_LIBRARY_PATH="${XROOTD_LIBDIR}:$LD_LIBRARY_PATH"
+# xrdfs fails LeakSanitizer; disable it temporarily
+export ASAN_OPTIONS=detect_leaks=0
 if ! "$XRDFS_BIN" "$CACHE_ROOT_URL" ls -l /test-public/subdir > "$BINARY_DIR/tests/$TEST_NAME/xrdfs.out"; then
   echo "Failed to list directory via root:// protocol"
   exit 1


### PR DESCRIPTION
This fixes two important issues:
- Segfault and incorrect state handling after a `Write` operation fails.
- Race condition that can prevent a callback from being invoked, causing the `Write` operation to effectively run forever.

Includes a multithreaded write test to help avoid future regressions.