### PR TITLE
Handle 404 when creating a file

### DIFF
--- a/src/CurlOps.hh
+++ b/src/CurlOps.hh
@@ -253,7 +253,16 @@ public:
     void ReleaseHandle() override;
     void Success() override;
 
+    // Invoked to handle a failure-to-open (HEAD returns non-200)
+    //
+    // If the open operation is invoked for a file with the `New` flag set, this
+    // may be a success if the remote server returned a 404.
+    void Fail(uint16_t errCode, uint32_t errNum, const std::string &) override;
+
 private:
+    // Set various common properties after an open has completed.
+    void SetOpenProperties();
+
     File *m_file{nullptr};
 };
 

--- a/src/PelicanFile.cc
+++ b/src/PelicanFile.cc
@@ -103,9 +103,7 @@ File::Open(const std::string      &url,
         return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
     }
 
-    // TODO: Handle the New and Delete flags; if they are set, then we must query the
-    // remote side and (possibly) delete the object
-    bool skipStat = (flags & XrdCl::OpenFlags::Write) || (flags & XrdCl::OpenFlags::Update);
+    m_open_flags = flags;
 
     m_header_timeout.tv_nsec = m_default_header_timeout.tv_nsec;
     m_header_timeout.tv_sec = m_default_header_timeout.tv_sec;
@@ -147,12 +145,6 @@ File::Open(const std::string      &url,
         m_is_pelican = true;
     } else {
         m_url = url;
-    }
-
-    if (skipStat) {
-        m_is_opened = true;
-        handler->HandleResponse(new XrdCl::XRootDStatus(), nullptr);
-        return XrdCl::XRootDStatus();
     }
 
     auto ts = GetHeaderTimeout(timeout);

--- a/src/PelicanFile.hh
+++ b/src/PelicanFile.hh
@@ -107,6 +107,9 @@ public:
     // Returns true if the origin URL was from the director cache.
     bool IsCachedUrl() const {return m_is_cached;}
 
+    // Returns the flags used to open the file
+    XrdCl::OpenFlags::Flags Flags() const {return m_open_flags;}
+
     // Sets the minimum client timeout
     static void SetMinimumHeaderTimeout(struct timespec &ts) {m_min_client_timeout.tv_sec = ts.tv_sec; m_min_client_timeout.tv_nsec = ts.tv_nsec;}
 
@@ -148,6 +151,10 @@ private:
     // This is used to determine whether we expect to get a redirect; if we don't, we'll
     // use the PROPFIND verb against the origin instead of HEAD against the director.
     bool m_is_cached{false};
+
+    // The flags used to open the file
+    XrdCl::OpenFlags::Flags m_open_flags{XrdCl::OpenFlags::None};
+
     std::string m_url;
     std::shared_ptr<HandlerQueue> m_queue;
     XrdCl::Log *m_logger{nullptr};

--- a/tests/pelican-test.sh
+++ b/tests/pelican-test.sh
@@ -142,7 +142,7 @@ if ! "$XRDFS_BIN" "$CACHE_ROOT_URL" ls -l /test-public/subdir/test3 > "$BINARY_D
   echo "Failed to list directory via root:// protocol"
   exit 1
 fi
-if ! grep -q 'http_Protocol:  Parsing first line: PROPFIND /test-public/subdir/test3?access_token=REDACTED HTTP/1.1" daemon=xrootd.origin' "$BINARY_DIR/tests/$TEST_NAME/pelican.log"; then
+if ! grep -E -q 'http_Protocol:  Parsing first line: PROPFIND /test-public/subdir/test3\?access_token=REDACTED.+xrootd.origin' "$BINARY_DIR/tests/$TEST_NAME/pelican.log"; then
   echo "access_token not specified in the xrootd origin log"
   exit 1
 fi


### PR DESCRIPTION
When opening a file that does not (yet) exist, we should initially stat the object (as it might be a directory -- in that case we should return an EISDIR).

If the stat fails with a 404 and we requested creating the file, then we should intercept the failure and proceed regardless.