### PR TITLE
Replace explicit is_pelican code with OPTIONS check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,8 +121,10 @@ add_library(XrdClPelicanObj OBJECT
   src/CurlUtil.cc src/CurlUtil.hh
   src/CurlListdir.cc
   src/CurlOps.cc src/CurlOps.hh
+  src/CurlOptions.cc
   src/CurlRead.cc
   src/CurlReadV.cc
+  src/OptionsCache.cc src/OptionsCache.hh
   src/PelicanFactory.cc src/PelicanFactory.hh
   src/PelicanFile.cc src/PelicanFile.hh
   src/PelicanFilesystem.cc src/PelicanFilesystem.hh

--- a/src/ChecksumCache.hh
+++ b/src/ChecksumCache.hh
@@ -174,7 +174,7 @@ public:
 
     void Put(const std::string &url, const ChecksumInfo &cinfo, const std::chrono::steady_clock::time_point &now=std::chrono::steady_clock::now()) const {
         auto host_and_path = GetUrlKey(url);
-        
+
         const std::unique_lock sentry(m_mutex);
         CEntry centry;
 
@@ -211,7 +211,7 @@ public:
 
     ChecksumInfo Get(const std::string &url, ChecksumTypeBitmask mask, const std::chrono::steady_clock::time_point &now=std::chrono::steady_clock::now()) const {
         auto host_and_path = GetUrlKey(url);
-        
+
         const std::shared_lock sentry(m_mutex);
         auto iter = m_checksums.find(host_and_path);
         ChecksumInfo cinfo;

--- a/src/CurlOps.cc
+++ b/src/CurlOps.cc
@@ -587,50 +587,6 @@ CurlOpenOp::Fail(uint16_t errCode, uint32_t errNum, const std::string &msg)
     CurlOperation::Fail(errCode, errNum, msg);
 }
 
-CurlListdirOp::CurlListdirOp(XrdCl::ResponseHandler *handler, const std::string &url, const std::string &host_addr, bool is_origin, struct timespec timeout,
-    XrdCl::Log *logger) :
-    CurlOperation(handler, url, timeout, logger),
-    m_is_origin(is_origin),
-    m_host_addr(host_addr),
-    m_header_list(nullptr, &curl_slist_free_all)
-{
-    m_minimum_rate = 1024.0 * 1;
-}
-
-void
-CurlListdirOp::Setup(CURL *curl, CurlWorker &worker)
-{
-    CurlOperation::Setup(curl, worker);
-    curl_easy_setopt(m_curl.get(), CURLOPT_WRITEFUNCTION, CurlListdirOp::WriteCallback);
-    curl_easy_setopt(m_curl.get(), CURLOPT_WRITEDATA, this);
-    curl_easy_setopt(m_curl.get(), CURLOPT_CUSTOMREQUEST, "PROPFIND");
-    m_header_list.reset(curl_slist_append(m_header_list.release(), "Depth: 1"));
-    curl_easy_setopt(m_curl.get(), CURLOPT_HTTPHEADER, m_header_list.get());
-}
-
-void
-CurlListdirOp::ReleaseHandle()
-{
-    if (m_curl == nullptr) return;
-    curl_easy_setopt(m_curl.get(), CURLOPT_WRITEFUNCTION, nullptr);
-    curl_easy_setopt(m_curl.get(), CURLOPT_WRITEDATA, nullptr);
-    curl_easy_setopt(m_curl.get(), CURLOPT_CUSTOMREQUEST, nullptr);
-    curl_easy_setopt(m_curl.get(), CURLOPT_HTTPHEADER, nullptr);
-    m_header_list.reset();
-    CurlOperation::ReleaseHandle();
-}
-
-size_t
-CurlListdirOp::WriteCallback(char *buffer, size_t size, size_t nitems, void *this_ptr)
-{
-    auto me = static_cast<CurlListdirOp*>(this_ptr);
-    if (size * nitems + me->m_response.size() > 10'000'000) {
-        return me->FailCallback(kXR_ServerError, "Response too large for PROPFIND operation");
-    }
-    me->m_response.append(buffer, size * nitems);
-    return size * nitems;
-}
-
 CurlCopyOp::CurlCopyOp(XrdCl::ResponseHandler *handler, const std::string &source_url, const Headers &source_hdrs,
 const std::string &dest_url, const Headers &dest_hdrs, struct timespec timeout, XrdCl::Log *logger) :
     CurlOperation(handler, dest_url, timeout, logger),

--- a/src/CurlOptions.cc
+++ b/src/CurlOptions.cc
@@ -1,0 +1,55 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "CurlOps.hh"
+
+using namespace Pelican;
+
+void
+CurlOptionsOp::Fail(uint16_t errCode, uint32_t errNum, const std::string &etext) {
+    CurlOperation::Fail(errCode, errNum, etext);
+    auto &cache = VerbsCache::Instance();
+    cache.Put(m_url, VerbsCache::HttpVerbs(VerbsCache::HttpVerb::kUnknown));
+    // 405 Method Not Supported; indicates that OPTIONS is not understood so
+    // we assume it's highly unlikely that non-HTTP verbs are supported (like
+    // PROPFIND); however, we don't fail the parent operation.
+    //
+    // Since the OPTIONS command is considered advisory, we ignore failures.
+}
+
+void
+CurlOptionsOp::Setup(CURL *curl, CurlWorker &worker) {
+    CurlOperation::Setup(curl, worker);
+    curl_easy_setopt(m_curl.get(), CURLOPT_CUSTOMREQUEST, "OPTIONS");
+    curl_easy_setopt(m_curl.get(), CURLOPT_NOBODY, 1L);
+}
+
+void
+CurlOptionsOp::Success() {
+    auto &cache = VerbsCache::Instance();
+    cache.Put(m_url, m_headers.GetAllowedVerbs());
+}
+
+void
+CurlOptionsOp::ReleaseHandle()
+{
+    if (m_curl == nullptr) return;
+    curl_easy_setopt(m_curl.get(), CURLOPT_CUSTOMREQUEST, nullptr);
+    curl_easy_setopt(m_curl.get(), CURLOPT_NOBODY, 0L);
+    CurlOperation::ReleaseHandle();
+}

--- a/src/CurlUtil.hh
+++ b/src/CurlUtil.hh
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "ChecksumCache.hh"
+#include "OptionsCache.hh"
 
 #include <condition_variable>
 #include <deque>
@@ -123,6 +124,11 @@ public:
         m_multipart_byteranges = true;
     }
 
+    VerbsCache::HttpVerbs GetAllowedVerbs() const
+    {
+        return VerbsCache::HttpVerbs(m_allow_verbs);
+    }
+
     std::string GetStatusMessage() const {return m_resp_message;}
 
     const std::string &GetLocation() const {return m_location;}
@@ -168,7 +174,6 @@ private:
 
     static bool validHeaderByte(unsigned char c);
 
-    std::unordered_map<std::string, std::vector<std::string>> m_header_map;
     int64_t m_content_length{-1};
     uint64_t m_response_offset{0};
 
@@ -187,6 +192,8 @@ private:
     std::string m_broker;
     std::string m_mirror_url;
     std::string m_multipart_sep;
+
+    VerbsCache::HttpVerb m_allow_verbs{VerbsCache::HttpVerb::kUnknown};
 };
 
 /**

--- a/src/CurlWorker.hh
+++ b/src/CurlWorker.hh
@@ -38,10 +38,11 @@ class URL;
 namespace Pelican {
 
 class HandlerQueue;
+class VerbsCache;
 
 class CurlWorker {
 public:
-    CurlWorker(std::shared_ptr<HandlerQueue> queue, XrdCl::Log* logger);
+    CurlWorker(std::shared_ptr<HandlerQueue> queue, VerbsCache &cache, XrdCl::Log* logger);
 
     CurlWorker(const CurlWorker &) = delete;
 
@@ -93,6 +94,7 @@ private:
 
     bool m_x509_all{false};
     std::chrono::steady_clock::time_point m_last_prefix_log;
+    VerbsCache &m_cache; // Cache mapping server URLs to list of selected HTTP verbs.
     std::shared_ptr<HandlerQueue> m_queue;
 
     // Queue for operations that can be unpaused.

--- a/src/OptionsCache.cc
+++ b/src/OptionsCache.cc
@@ -1,0 +1,55 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "OptionsCache.hh"
+
+#include <curl/curl.h>
+
+#include <thread>
+
+Pelican::VerbsCache Pelican::VerbsCache::g_cache;
+std::once_flag Pelican::VerbsCache::m_expiry_launch;
+
+Pelican::VerbsCache & Pelican::VerbsCache::Instance() {
+    std::call_once(m_expiry_launch, [] {
+        std::thread t(VerbsCache::ExpireThread);
+        t.detach();
+    });
+    return g_cache;
+}
+
+void Pelican::VerbsCache::ExpireThread()
+{
+    while (true) {
+        std::this_thread::sleep_for(std::chrono::seconds(30));
+        auto now = std::chrono::steady_clock::now();
+        g_cache.Expire(now);
+    }
+}
+
+void Pelican::VerbsCache::Expire(std::chrono::steady_clock::time_point now)
+{
+    std::unique_lock lock(m_mutex);
+    for (auto iter = m_verbs_map.begin(); iter != m_verbs_map.end();) {
+        if (iter->second.m_expiry < now) {
+            iter = m_verbs_map.erase(iter);
+        } else {
+            ++iter;
+        }
+    }
+}

--- a/src/OptionsCache.hh
+++ b/src/OptionsCache.hh
@@ -1,0 +1,174 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#ifndef _OPTIONSCACHE_HH__
+#define _OPTIONSCACHE_HH__
+
+#include <array>
+#include <chrono>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+ 
+ namespace Pelican {
+ 
+ // A cache holding the known HTTP verbs for a given endpoint.
+ class VerbsCache {
+ public:
+ 
+    // Enumeration bitmask of the HTTP verbs that we can test for
+    enum class HttpVerb {
+        kUnset = 0, // Indicates that we haven't yet probed for the HTTP verb support.
+        kUnknown = 1, // Indicates we probed for support but the result was indeterminate (not provided by the server, network error)
+        kPROPFIND = 2, // Server claims to support PROPFIND
+    };
+    class HttpVerbs {
+    public:
+        HttpVerbs() = default;
+        HttpVerbs(HttpVerb verb) : m_verbs(static_cast<unsigned>(verb)) {}
+        HttpVerbs &operator|=(HttpVerb verb) {m_verbs |= static_cast<unsigned>(verb); return *this;}
+        bool IsSet(HttpVerb verb) const
+        {
+            if (verb == HttpVerb::kUnset) {return !m_verbs;}
+            return static_cast<unsigned>(m_verbs) & static_cast<unsigned>(verb);
+        }
+        unsigned GetValue() const {return m_verbs;}
+    private:
+        unsigned m_verbs{0};
+    };
+ 
+    static const std::string GetVerbString(HttpVerb ctype) {
+        switch (ctype) {
+            case HttpVerb::kUnset:
+                return "(unset)";
+            case HttpVerb::kUnknown:
+                return "(unknown)";
+            case HttpVerb::kPROPFIND:
+                return "PROPFIND";
+        }
+    }
+
+    void Put(const std::string &url, const HttpVerbs &verbs, const std::chrono::steady_clock::time_point &now=std::chrono::steady_clock::now()) const {
+        std::string modified_url;
+        auto key = GetUrlKey(url, modified_url);
+
+        const std::unique_lock sentry(m_mutex);
+
+        auto isKnown = !verbs.IsSet(HttpVerb::kUnknown);
+        auto lifetime = isKnown ? g_expiry_duration : g_negative_expiry_duration;
+
+        auto iter = m_verbs_map.find(key);
+        if (iter == m_verbs_map.end()) {
+            m_verbs_map.emplace(key, VerbEntry{now + lifetime, verbs});
+        } else if (isKnown || iter->second.m_verbs.IsSet(HttpVerb::kUnknown)) {
+            // Previous entry didn't know the verbs, but now we do
+            iter->second = {now + lifetime, verbs};
+        }
+    }
+
+    HttpVerbs Get(const std::string &url, const std::chrono::steady_clock::time_point &now=std::chrono::steady_clock::now()) const {
+        std::string modified_url;
+        auto key = GetUrlKey(url, modified_url);
+
+        const std::shared_lock sentry(m_mutex);
+        auto iter = m_verbs_map.find(key);
+        if (iter == m_verbs_map.end()) {
+            m_cache_miss++;
+            return HttpVerbs{};
+        }
+        if (iter->second.m_expiry < now) {
+            m_cache_miss++;
+            return HttpVerbs{};
+        }
+        m_cache_hit++;
+        return iter->second.m_verbs;
+    }
+
+    // Get the cache key for a given URL
+    //
+    // Cache key should consist of the schema, host, and port portion of the URL.
+    static std::string_view GetUrlKey(const std::string &url, std::string &modified_url) {
+        auto authority_loc = url.find("://");
+        if (authority_loc == std::string::npos) {
+            return std::string_view();
+        }
+        auto path_loc = url.find('/', authority_loc + 3);
+        if (path_loc == std::string::npos) {
+            path_loc = url.length();
+        }
+
+        std::string_view url_view{url};
+        auto host_loc = url_view.substr(authority_loc + 3, path_loc - authority_loc - 3).find('@');
+        if (host_loc == std::string::npos) {
+            return url_view.substr(0, path_loc);
+        }
+        host_loc += authority_loc + 3;
+        modified_url = url.substr(0, authority_loc + 3) + std::string(url_view.substr(host_loc + 1, path_loc - host_loc - 1));
+        return modified_url;
+    }
+
+    uint64_t GetCacheHits() const {return m_cache_hit;}
+    uint64_t GetCacheMisses() const {return m_cache_miss;}
+
+    // Expire all entries in the cache whose expiration is older than `now`.
+    void Expire(std::chrono::steady_clock::time_point now);
+
+    // Return the global instance of the verbs cache.
+    static VerbsCache &Instance();
+
+private:
+    VerbsCache() = default;
+    VerbsCache(const VerbsCache &) = delete;
+    VerbsCache(VerbsCache &&) = delete;
+
+    // Background thread periodically invoking `Expire` on the cache.
+    static void ExpireThread();
+
+    mutable std::atomic<uint64_t> m_cache_hit{0};
+    mutable std::atomic<uint64_t> m_cache_miss{0};
+
+    template<typename ... Bases>
+    struct overload : Bases ...
+    {
+        using is_transparent = void;
+        using Bases::operator() ... ;
+    };
+    using transparent_string_hash = overload<
+        std::hash<std::string>,
+        std::hash<std::string_view>
+    >;
+
+    struct VerbEntry {
+        std::chrono::steady_clock::time_point m_expiry;
+        HttpVerbs m_verbs;
+    };
+
+    mutable std::shared_mutex m_mutex;
+    mutable std::unordered_map<std::string, VerbEntry, VerbsCache::transparent_string_hash, std::equal_to<>> m_verbs_map;
+
+    static std::once_flag m_expiry_launch;
+    static VerbsCache g_cache;
+    static constexpr std::chrono::steady_clock::duration g_expiry_duration = std::chrono::hours(6);
+    static constexpr std::chrono::steady_clock::duration g_negative_expiry_duration = std::chrono::minutes(15);
+ };
+ 
+ } // namespace Pelican
+ 
+ #endif // _OPTIONSCACHE_HH__

--- a/src/PelicanFactory.cc
+++ b/src/PelicanFactory.cc
@@ -16,6 +16,7 @@
  *
  ***************************************************************/
 
+#include "OptionsCache.hh"
 #include "ParseTimeout.hh"
 #include "PelicanFactory.hh"
 #include "PelicanFile.hh"
@@ -173,9 +174,12 @@ PelicanFactory::PelicanFactory() {
         }
         File::SetFederationMetadataTimeout(fedTimeout);
 
+        // Start up the cache for the OPTIONS response
+        auto &cache = VerbsCache::Instance();
+
         // Startup curl workers after we've set the configs to avoid race conditions
         for (unsigned idx=0; idx<m_poll_threads; idx++) {
-            m_workers.emplace_back(new CurlWorker(m_queue, m_log));
+            m_workers.emplace_back(new CurlWorker(m_queue, cache, m_log));
             std::thread t(CurlWorker::RunStatic, m_workers.back().get());
             t.detach();
         }

--- a/src/PelicanFilesystem.cc
+++ b/src/PelicanFilesystem.cc
@@ -118,7 +118,7 @@ Filesystem::Stat(const std::string      &path,
     }
 
     m_logger->Debug(kLogXrdClPelican, "Filesystem::Stat path %s", full_url.c_str());
-    std::unique_ptr<CurlStatOp> statOp(new CurlStatOp(handler, full_url, ts, m_logger, is_pelican, is_cached, dcache));
+    std::unique_ptr<CurlStatOp> statOp(new CurlStatOp(handler, full_url, ts, m_logger, is_cached, dcache));
     try {
         m_queue->Produce(std::move(statOp));
     } catch (...) {

--- a/tests/ChecksumTest.cc
+++ b/tests/ChecksumTest.cc
@@ -128,6 +128,8 @@ TEST_F(ChecksumFixture, Basic)
     std::tie(status2, obj2) = srh.Status();
     ASSERT_EQ(status2->IsOK(), true);
 
-    ASSERT_EQ(hits + 1, ccache.GetCacheHits());
-    ASSERT_EQ(misses + 2, ccache.GetCacheMisses());
+    // Note: the cache hit is only expected when we use pelican://-style URLs; if it's
+    // a http://-style URL, we never cache checksum information.
+    ASSERT_EQ(hits, ccache.GetCacheHits());
+    ASSERT_EQ(misses + 3, ccache.GetCacheMisses());
 }

--- a/tests/pelican-setup.sh
+++ b/tests/pelican-setup.sh
@@ -131,6 +131,7 @@ Director:
   EnableStat: false
   checkcachepresence: false
   checkoriginpresence: false
+  OriginCacheHealthTestInterval: 1h
 
 Registry:
   DbLocation: $PELICAN_RUNDIR/registry.sqlite


### PR DESCRIPTION
Check for allowed verbs with the OPTIONS request; if PROPFIND is in the list of allowed verbs, then use that for stat; otherwise, use HEAD.

This is the proper thing to do for a generic HTTP server -- and it happens to have the correct behavior around the Pelican director. The director returns a 405 on the OPTIONS request, causing the new code to use a HEAD against the director which is the correct thing to do for Pelican.

This subsequently allows us to remove Pelican-specific code paths, a step in preparing for an ultimate split between the generic HTTP code and Pelican-specific code.

Fixes: #43 