### PR TITLE
Add query of cache-control attributes in XrdClCurl::FileSystem::Query() and XrdClCurl::File::Fcntl()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ add_library(XrdClCurlObj OBJECT
   src/XrdClCurl/CurlOps.cc src/XrdClCurl/CurlOps.hh
   src/XrdClCurl/CurlOptions.cc
   src/XrdClCurl/CurlPut.cc
+  src/XrdClCurl/CurlQuery.cc
   src/XrdClCurl/CurlRead.cc
   src/XrdClCurl/CurlReadV.cc
   src/XrdClCurl/CurlStat.cc

--- a/src/XrdClCurl/CurlFile.cc
+++ b/src/XrdClCurl/CurlFile.cc
@@ -29,6 +29,10 @@
 #include <XrdCl/XrdClStatus.hh>
 #include <XrdCl/XrdClURL.hh>
 
+#include <nlohmann/json.hpp>
+#include <iostream>
+#include <regex>
+
 using namespace XrdClCurl;
 
 // Note: these values are typically overwritten by `CurlFactory::CurlFactory`;
@@ -244,6 +248,107 @@ File::Stat(bool                    /*force*/,
         XrdCl::StatInfo::Flags::IsReadable, time(NULL));
     auto obj = new XrdCl::AnyObject();
     obj->Set(stat_info);
+
+    handler->HandleResponse(new XrdCl::XRootDStatus(), obj);
+    return XrdCl::XRootDStatus();
+}
+
+XrdCl::XRootDStatus
+File::Fcntl(const XrdCl::Buffer &arg, XrdCl::ResponseHandler *handler,
+           timeout_t               timeout)
+{
+    if (!m_is_opened) {
+        m_logger->Error(kLogXrdClCurl, "Cannot run fcntl.  URL isn't open");
+        return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+    }
+
+    auto obj = new XrdCl::AnyObject();
+    std::string as = arg.ToString();
+    try
+    {
+        XrdCl::QueryCode::Code code = (XrdCl::QueryCode::Code)std::stoi(as);
+        if (code == XrdCl::QueryCode::XAttr)
+        {
+            nlohmann::json xatt;
+            std::string etagRes;
+            if (GetProperty("ETag", etagRes))
+            {
+                xatt["ETag"] = etagRes;
+            }
+            std::string cc;
+            if (GetProperty("Cache-Control", cc))
+            {
+                if (cc.find("must-revalidate") != std::string::npos)
+                {
+                    xatt["revalidate"] = true;
+                }
+                size_t fm = cc.find("max-age=");
+                if (fm != std::string::npos)
+                {
+                    fm += 9; // idx of the first character after the make-age= match
+                    for (size_t i = fm; i < cc.length(); i++)
+                    {
+                        if (!std::isdigit(cc[i]))
+                        {
+                            std::string sa = cc.substr(fm, i);
+                            long int a = std::stol(sa);
+                            time_t t = time(NULL) + a;
+                            xatt["expire"] = t;
+                            break;
+                        }
+                    }
+                }
+            }
+            XrdCl::Buffer *respBuff = new XrdCl::Buffer();
+            m_logger->Debug(kLogXrdClCurl, "Fcntl conent %s", xatt.dump().c_str());
+            respBuff->FromString(xatt.dump());
+            obj->Set(respBuff);
+        }
+        //
+        //   Query codes supported by  XrdCl::File::Fctnl
+        //
+        else if (code == XrdCl::QueryCode::Stats)
+        {
+            m_logger->Error(kLogXrdClCurl, "Server status query not supported.");
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+        }
+        else if (code == XrdCl::QueryCode::Checksum || code == XrdCl::QueryCode::ChecksumCancel)
+        {
+            m_logger->Error(kLogXrdClCurl, "Checksum query not supported.");
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+        }
+        else if (code == XrdCl::QueryCode::Config)
+        {
+            m_logger->Error(kLogXrdClCurl, "Server configuration query not supported.");
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+        }
+        else if (code == XrdCl::QueryCode::Space)
+        {
+            m_logger->Error(kLogXrdClCurl, "Local space stats query not supported.");
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+        }
+        else if (code == XrdCl::QueryCode::Opaque || code == XrdCl::QueryCode::OpaqueFile)
+        {
+            // XrdCl implementation dependent
+            m_logger->Error(kLogXrdClCurl, "Opaque query not supported.");
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+        }
+        else if (code == XrdCl::QueryCode::Prepare)
+        {
+            m_logger->Error(kLogXrdClCurl, "Prepare status query not supported.");
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+        }
+        else
+        {
+            m_logger->Error(kLogXrdClCurl, "Invalid information query type code");
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidArgs);
+        }
+    }
+    catch (const std::exception& e)
+    {
+        m_logger->Warning(kLogXrdClCurl, "Failed to parse query code %s", e.what());
+        return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errDataError);
+    }
 
     handler->HandleResponse(new XrdCl::XRootDStatus(), obj);
     return XrdCl::XRootDStatus();

--- a/src/XrdClCurl/CurlFile.cc
+++ b/src/XrdClCurl/CurlFile.cc
@@ -31,7 +31,6 @@
 
 #include <nlohmann/json.hpp>
 #include <iostream>
-#include <regex>
 
 using namespace XrdClCurl;
 

--- a/src/XrdClCurl/CurlFile.hh
+++ b/src/XrdClCurl/CurlFile.hh
@@ -71,6 +71,10 @@ public:
                                     XrdCl::ResponseHandler *handler,
                                     timeout_t               timeout) override;
 
+    virtual XrdCl::XRootDStatus Fcntl(const XrdCl::Buffer    &arg,
+                                    XrdCl::ResponseHandler *handler,
+                                    timeout_t               timeout) override;
+
     virtual XrdCl::XRootDStatus Read(uint64_t                offset,
                                     uint32_t                size,
                                     void                   *buffer,

--- a/src/XrdClCurl/CurlFilesystem.cc
+++ b/src/XrdClCurl/CurlFilesystem.cc
@@ -194,10 +194,10 @@ XrdCl::XRootDStatus Filesystem::Query(XrdCl::QueryCode::Code  queryCode,
         std::string full_url = m_url.GetURL();
         m_logger->Debug(kLogXrdClCurl, "XrdClCurl::Filesystem::Query xattr full_url %s, path %s", full_url.c_str(), path.c_str());
         full_url = m_url.GetURL();
-        std::unique_ptr<CurlQueryOp> statOp(new CurlQueryOp(handler, path, ts, m_logger,SendResponseInfo(), GetConnCallout(), queryCode));
+        std::unique_ptr<CurlQueryOp> queryOp(new CurlQueryOp(handler, path, ts, m_logger,SendResponseInfo(), GetConnCallout(), queryCode));
         try
         {
-            m_queue->Produce(std::move(statOp));
+            m_queue->Produce(std::move(queryOp));
         }
         catch (...)
         {

--- a/src/XrdClCurl/CurlFilesystem.cc
+++ b/src/XrdClCurl/CurlFilesystem.cc
@@ -154,11 +154,11 @@ XrdCl::XRootDStatus Filesystem::Query(XrdCl::QueryCode::Code  queryCode,
     XrdCl::ResponseHandler  *handler,
     timeout_t                timeout)
 {
-    auto url = GetCurrentURL(arg.ToString());
     auto ts = XrdClCurl::Factory::GetHeaderTimeoutWithDefault(timeout);
 
     if (queryCode == XrdCl::QueryCode::Checksum)
     {
+        auto url = GetCurrentURL(arg.ToString());
         m_logger->Debug(kLogXrdClCurl, "XrdClCurl::Filesystem::Query checksum path %s", url.c_str());
 
         XrdClCurl::ChecksumType preferred = XrdClCurl::ChecksumType::kCRC32C;
@@ -190,9 +190,11 @@ XrdCl::XRootDStatus Filesystem::Query(XrdCl::QueryCode::Code  queryCode,
     }
     else if (queryCode == XrdCl::QueryCode::XAttr)
     {
-        m_logger->Debug(kLogXrdClCurl, "XrdClCurl::Filesystem::Query xattr path %s", url.c_str());
-
-        std::unique_ptr<CurlQueryOp> statOp(new CurlQueryOp(handler, url, ts, m_logger,SendResponseInfo(), GetConnCallout(), queryCode));
+        std::string path = arg.ToString();
+        std::string full_url = m_url.GetURL();
+        m_logger->Debug(kLogXrdClCurl, "XrdClCurl::Filesystem::Query xattr full_url %s, path %s", full_url.c_str(), path.c_str());
+        full_url = m_url.GetURL();
+        std::unique_ptr<CurlQueryOp> statOp(new CurlQueryOp(handler, path, ts, m_logger,SendResponseInfo(), GetConnCallout(), queryCode));
         try
         {
             m_queue->Produce(std::move(statOp));

--- a/src/XrdClCurl/CurlOpen.cc
+++ b/src/XrdClCurl/CurlOpen.cc
@@ -20,7 +20,8 @@
 #include "CurlOps.hh"
 
 #include <XrdCl/XrdClLog.hh>
-
+#include "../common/CurlResponseInfo.hh"
+#include "../common/CurlResponses.hh"
 
 using namespace XrdClCurl;
 
@@ -49,6 +50,14 @@ CurlOpenOp::SetOpenProperties()
     if (url && m_file) {
         m_file->SetProperty("LastURL", url);
     }
+
+    if (!m_headers.GetETag().empty())
+    {
+        std::string etag = m_headers.GetETag();
+        etag.erase(remove(etag.begin(), etag.end(), '\"'), etag.end());
+        m_file->SetProperty("ETag", etag);
+    }
+    m_file->SetProperty("Cache-Control", m_headers.GetCacheControl());
 }
 
 void

--- a/src/XrdClCurl/CurlOpen.cc
+++ b/src/XrdClCurl/CurlOpen.cc
@@ -54,7 +54,6 @@ CurlOpenOp::SetOpenProperties()
     if (!m_headers.GetETag().empty())
     {
         std::string etag = m_headers.GetETag();
-        etag.erase(remove(etag.begin(), etag.end(), '\"'), etag.end());
         m_file->SetProperty("ETag", etag);
     }
     m_file->SetProperty("Cache-Control", m_headers.GetCacheControl());

--- a/src/XrdClCurl/CurlOps.cc
+++ b/src/XrdClCurl/CurlOps.cc
@@ -376,3 +376,20 @@ CurlOperation::WaitSocketCallback(std::string &err)
     }
     return m_conn_callout_result;
 }
+
+// ------------------------ BEGIN QUERY OPS -------
+//
+void CurlQueryOp::Success()
+{
+    SetDone(false); // ???
+    m_logger->Debug(kLogXrdClCurl, "CurlQueryOp::Success");
+
+    XrdCl::Buffer* qInfo = new XrdCl::Buffer();
+    qInfo->FromString(m_headers.GetETag());
+    auto obj = new XrdCl::AnyObject();
+    obj->Set(qInfo);
+
+
+    m_handler->HandleResponse(new XrdCl::XRootDStatus(), obj);
+    m_handler = nullptr;
+}

--- a/src/XrdClCurl/CurlOps.cc
+++ b/src/XrdClCurl/CurlOps.cc
@@ -379,17 +379,23 @@ CurlOperation::WaitSocketCallback(std::string &err)
 
 // ------------------------ BEGIN QUERY OPS -------
 //
+#include <XrdCl/XrdClFileSystem.hh>
 void CurlQueryOp::Success()
 {
     SetDone(false); // ???
     m_logger->Debug(kLogXrdClCurl, "CurlQueryOp::Success");
 
-    XrdCl::Buffer* qInfo = new XrdCl::Buffer();
-    qInfo->FromString(m_headers.GetETag());
-    auto obj = new XrdCl::AnyObject();
-    obj->Set(qInfo);
+    if (m_queryCode == XrdCl::QueryCode::XAttr) {
+        XrdCl::Buffer *qInfo = new XrdCl::Buffer();
+        qInfo->FromString(m_headers.GetETag());
+        auto obj = new XrdCl::AnyObject();
+        obj->Set(qInfo);
 
-
-    m_handler->HandleResponse(new XrdCl::XRootDStatus(), obj);
-    m_handler = nullptr;
+        m_handler->HandleResponse(new XrdCl::XRootDStatus(), obj);
+        m_handler = nullptr;
+    }
+    else {
+        m_logger->Error(kLogXrdClCurl, "Invalid information query type code");
+        Fail(XrdCl::errInvalidArgs, XrdCl::errErrorResponse, "Unsupported query code");
+    }
 }

--- a/src/XrdClCurl/CurlOps.cc
+++ b/src/XrdClCurl/CurlOps.cc
@@ -376,26 +376,3 @@ CurlOperation::WaitSocketCallback(std::string &err)
     }
     return m_conn_callout_result;
 }
-
-// ------------------------ BEGIN QUERY OPS -------
-//
-#include <XrdCl/XrdClFileSystem.hh>
-void CurlQueryOp::Success()
-{
-    SetDone(false); // ???
-    m_logger->Debug(kLogXrdClCurl, "CurlQueryOp::Success");
-
-    if (m_queryCode == XrdCl::QueryCode::XAttr) {
-        XrdCl::Buffer *qInfo = new XrdCl::Buffer();
-        qInfo->FromString(m_headers.GetETag());
-        auto obj = new XrdCl::AnyObject();
-        obj->Set(qInfo);
-
-        m_handler->HandleResponse(new XrdCl::XRootDStatus(), obj);
-        m_handler = nullptr;
-    }
-    else {
-        m_logger->Error(kLogXrdClCurl, "Invalid information query type code");
-        Fail(XrdCl::errInvalidArgs, XrdCl::errErrorResponse, "Unsupported query code");
-    }
-}

--- a/src/XrdClCurl/CurlOps.hh
+++ b/src/XrdClCurl/CurlOps.hh
@@ -477,6 +477,25 @@ private:
     bool m_response_info{false}; // Indicate whether to give extended information in the response.
 };
 
+//  Cache control query
+//
+class CurlQueryOp final : public CurlStatOp {
+public:
+ CurlQueryOp(XrdCl::ResponseHandler *handler, const std::string &url, struct timespec timeout,
+        XrdCl::Log *log, bool response_info, CreateConnCalloutType callout, int queryCode) :
+    CurlStatOp(handler, url, timeout, log, response_info, callout),
+    m_queryCode(queryCode)
+    {
+    }
+
+    virtual ~CurlQueryOp() {}
+
+    void Success() override;
+
+    int  m_queryCode;
+    std::string m_queryVal;
+};
+
 class CurlReadOp : public CurlOperation {
 public:
     CurlReadOp(XrdCl::ResponseHandler *handler, const std::string &url, struct timespec timeout,

--- a/src/XrdClCurl/CurlQuery.cc
+++ b/src/XrdClCurl/CurlQuery.cc
@@ -1,0 +1,43 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "CurlOps.hh"
+#include <XrdCl/XrdClFileSystem.hh>
+#include <XrdCl/XrdClLog.hh>
+
+using namespace XrdClCurl;
+
+void CurlQueryOp::Success()
+{
+    SetDone(false);
+    m_logger->Debug(kLogXrdClCurl, "CurlQueryOp::Success");
+
+    if (m_queryCode == XrdCl::QueryCode::XAttr) {
+        XrdCl::Buffer *qInfo = new XrdCl::Buffer();
+        qInfo->FromString(m_headers.GetETag());
+        auto obj = new XrdCl::AnyObject();
+        obj->Set(qInfo);
+
+        m_handler->HandleResponse(new XrdCl::XRootDStatus(), obj);
+        m_handler = nullptr;
+    }
+    else {
+        m_logger->Error(kLogXrdClCurl, "Invalid information query type code");
+        Fail(XrdCl::errInvalidArgs, XrdCl::errErrorResponse, "Unsupported query code");
+    }
+}

--- a/src/XrdClCurl/CurlUtil.cc
+++ b/src/XrdClCurl/CurlUtil.cc
@@ -379,9 +379,16 @@ bool HeaderParser::Parse(const std::string &header_line)
         m_location = header_value;
     } else if (header_name == "Digest") {
         ParseDigest(header_value, m_checksums);
-    } else if (header_name == "ETag") {
+    }
+    else if (header_name == "Etag")
+    {
+        // Note, the original hader name is ETag, renamed to Etag in parsing
+        // remove additional quotes
         m_etag = header_value;
-    } else if (header_name == "Cache-Control") {
+        m_etag.erase(remove(m_etag.begin(), m_etag.end(), '\"'), m_etag.end());
+    }
+    else if (header_name == "Cache-Control")
+    {
         m_cache_control = header_value;
     }
 

--- a/src/XrdClCurl/CurlUtil.cc
+++ b/src/XrdClCurl/CurlUtil.cc
@@ -379,6 +379,10 @@ bool HeaderParser::Parse(const std::string &header_line)
         m_location = header_value;
     } else if (header_name == "Digest") {
         ParseDigest(header_value, m_checksums);
+    } else if (header_name == "ETag") {
+        m_etag = header_value;
+    } else if (header_name == "Cache-Control") {
+        m_cache_control = header_value;
     }
 
     return true;

--- a/src/XrdClCurl/CurlUtil.hh
+++ b/src/XrdClCurl/CurlUtil.hh
@@ -112,6 +112,8 @@ public:
     std::string GetStatusMessage() const {return m_resp_message;}
 
     const std::string &GetLocation() const {return m_location;}
+    const std::string &GetETag() const {return m_etag;}
+    const std::string &GetCacheControl() const {return m_cache_control;}
 
     // Returns a reference to the checksums parsed from the headers.
     const XrdClCurl::ChecksumInfo &GetChecksums() const {return m_checksums;}
@@ -143,6 +145,8 @@ private:
     std::string m_resp_message;
     std::string m_location;
     std::string m_multipart_sep;
+    std::string m_etag;
+    std::string m_cache_control;
 
     ResponseInfo::HeaderMap m_headers;
 


### PR DESCRIPTION
The change are related to xrootd development in branch https://github.com/alja/xrootd/tree/etag-master.