### PR TITLE
Fix querying the wrong resource name

### DIFF
--- a/src/XrdClCurl/CurlUtil.cc
+++ b/src/XrdClCurl/CurlUtil.cc
@@ -872,6 +872,7 @@ CurlWorker::Run() {
                 op->Fail(XrdCl::errInternal, mres, "Unable to add operation to the curl multi-handle");
                 continue;
             }
+            m_logger->Debug(kLogXrdClCurl, "Added request for URL %s to worker thread for processing", op->GetUrl().c_str());
             running_handles += 1;
         }
 


### PR DESCRIPTION
When a cache wants to query the director for an origin, it needs to prepend a resource name (`/api/v1.0/director/object`) otherwise the director interprets the request as a query for a cache (resulting in a loop in some setups).

On a happy note - with this change, the Pelican unit tests now successfully run against the v1.3.x code!