### PR TITLE
Fix parsing of `depth` header

### DIFF
--- a/tests/XrdClPelican/CMakeLists.txt
+++ b/tests/XrdClPelican/CMakeLists.txt
@@ -7,19 +7,30 @@ include( GoogleTest )
 
 add_executable( xrdcl-pelican-test
   CacheToken.cc
-  ChecksumCache.cc
   ChecksumTest.cc
+)
+
+# Unit tests that do not require the pelican fixture
+add_executable( xrdcl-pelican-unit
+  ChecksumCache.cc
   DirectorCacheTest.cc
   HeaderParser.cc
 )
 
 target_link_libraries( xrdcl-pelican-test XrdClPelicanTesting XrdClCurlTesting XrdClCurlTransferTest GTest::gtest_main )
+target_link_libraries( xrdcl-pelican-unit XrdClPelicanTesting XrdClCurlTesting XRootD::XrdCl GTest::gtest_main )
 
 gtest_add_tests( TARGET xrdcl-pelican-test TEST_LIST PelicanTests )
 set_tests_properties( ${PelicanTests}
   PROPERTIES
     FIXTURES_REQUIRED XrdClPelican::pelican
     ENVIRONMENT "XRD_LOGLEVEL=Debug;ENV_FILE=${CMAKE_BINARY_DIR}/tests/pelican/setup.sh;XRD_PLUGINCONFDIR=${CMAKE_BINARY_DIR}/tests/pelican/client.plugins.d;LD_LIBRARY_PATH=${XRootD_LIB_DIR}:$ENV{LD_LIBRARY_PATH}"
+)
+
+gtest_add_tests( TARGET xrdcl-pelican-unit TEST_LIST PelicanUnitTests )
+set_tests_properties( ${PelicanUnitTests}
+  PROPERTIES
+    ENVIRONMENT "LD_LIBRARY_PATH=${XRootD_LIB_DIR}"
 )
 
 ######################################


### PR DESCRIPTION
Previously, if the director responded with invalid depth settings (basically, larger than the actual depth of the URL), then the worker thread would raise an exception.  This could kill off the running queries in that thread, potentially blocking an open call (and causing that file to stall until the cache service is restarted).