### PR TITLE
Additional S3 implementations

### DIFF
--- a/src/XrdClCurl/CurlFilesystem.cc
+++ b/src/XrdClCurl/CurlFilesystem.cc
@@ -249,6 +249,14 @@ Filesystem::Rm(const std::string      &path,
     return XrdCl::XRootDStatus();
 }
 
+XrdCl::XRootDStatus
+Filesystem::RmDir(const std::string      &path,
+                  XrdCl::ResponseHandler *handler,
+                  timeout_t               timeout)
+{
+    return Rm(path, handler, timeout);
+}
+
 bool
 Filesystem::SetProperty(const std::string &name,
                         const std::string &value)

--- a/src/XrdClCurl/CurlFilesystem.hh
+++ b/src/XrdClCurl/CurlFilesystem.hh
@@ -78,6 +78,10 @@ public:
                                    XrdCl::ResponseHandler *handler,
                                    timeout_t               timeout) override;
 
+    virtual XrdCl::XRootDStatus RmDir(const std::string      &path,
+                                      XrdCl::ResponseHandler *handler,
+                                      timeout_t               timeout) override;
+
     virtual bool SetProperty(const std::string &name,
                              const std::string &value) override;
 

--- a/src/XrdClS3/S3Factory.cc
+++ b/src/XrdClS3/S3Factory.cc
@@ -39,6 +39,7 @@ std::string Factory::m_endpoint = "";
 std::string Factory::m_service = "s3";
 std::string Factory::m_region = "us-east-1";
 std::string Factory::m_url_style = "virtual";
+std::string Factory::m_mkdir_sentinel;
 Factory::Credentials Factory::m_default_creds;
 std::unordered_map<std::string, Factory::Credentials> Factory::m_bucket_location_map;
 std::unordered_map<std::string, std::pair<Factory::Credentials, std::chrono::steady_clock::time_point>> Factory::m_bucket_auth_map;
@@ -350,6 +351,7 @@ void
 Factory::InitS3Config()
 {
     auto env = XrdCl::DefaultEnv::GetEnv();
+    SetDefault(env, "XrdClS3MkdirSentinel", "XRDCLS3_MKDIRSENTINEL", m_mkdir_sentinel, ".xrdcls3.dirsentinel");
     SetDefault(env, "XrdClS3Endpoint", "XRDCLS3_ENDPOINT", m_endpoint, "");
     SetDefault(env, "XrdClS3UrlStyle", "XRDCLS3_URLSTYLE", m_url_style, "virtual");
     SetDefault(env, "XrdClS3Region", "XRDCLS3_REGION", m_region, "us-east-1");

--- a/src/XrdClS3/S3Factory.hh
+++ b/src/XrdClS3/S3Factory.hh
@@ -76,6 +76,8 @@ public:
     // Helper function to remove XRootD-specific query parameters from an object name
     static std::string CleanObjectName(const std::string &object);
 
+    static const std::string &GetMkdirSentinel() {return m_mkdir_sentinel;}
+
     // Setters for the S3 endpoint, service, region, and URL style.
     // Intended to be used for testing or configuration purposes.
     static void SetEndpoint(const std::string &endpoint) { m_endpoint = endpoint; }
@@ -112,6 +114,13 @@ private:
     static std::string m_service;
     static std::string m_region;
     static std::string m_url_style;
+
+    // S3 doesn't have the concept of "directories"; if a given name
+    // (some/path) has an object containing it as a prefix
+    // (some/path/foo.txt), then we say it's a directory.  Hence, to
+    // "make" a directory, we create a zero-length sentinel file inside
+    // it; this static variable controls the name.
+    static std::string m_mkdir_sentinel;
 
     // Struct describing S3 credentials
     struct Credentials {

--- a/src/XrdClS3/S3File.cc
+++ b/src/XrdClS3/S3File.cc
@@ -105,7 +105,14 @@ bool
 File::GetProperty(const std::string &name,
                   std::string &value) const
 {
-    return false;
+    std::unique_lock lock(m_properties_mutex);
+    const auto p = m_properties.find(name);
+    if (p == std::end(m_properties)) {
+        return false;
+    }
+
+    value = p->second;
+    return true;
 }
 
 std::tuple<XrdCl::XRootDStatus, std::string, XrdCl::File*>
@@ -203,7 +210,9 @@ bool
 File::SetProperty(const std::string &name,
                   const std::string &value)
 {
-    return false;
+    std::unique_lock lock(m_properties_mutex);
+    m_properties[name] = value;
+    return true;
 }
 
 XrdCl::XRootDStatus

--- a/src/XrdClS3/S3Filesystem.cc
+++ b/src/XrdClS3/S3Filesystem.cc
@@ -525,7 +525,14 @@ bool
 Filesystem::GetProperty(const std::string &name,
                         std::string       &value) const
 {
-    return false;
+    std::unique_lock lock(m_properties_mutex);
+    const auto p = m_properties.find(name);
+    if (p == std::end(m_properties)) {
+        return false;
+    }
+
+    value = p->second;
+    return true;
 }
 
 XrdCl::XRootDStatus
@@ -643,11 +650,14 @@ Filesystem::RmDir(const std::string      &input_path,
     return Rm(path, handler, timeout);
 }
 
+
 bool
 Filesystem::SetProperty(const std::string &name,
                         const std::string &value)
 {
-    return false;
+    std::unique_lock lock(m_properties_mutex);
+    m_properties[name] = value;
+    return true;
 }
 
 XrdCl::XRootDStatus

--- a/src/XrdClS3/S3Filesystem.hh
+++ b/src/XrdClS3/S3Filesystem.hh
@@ -61,10 +61,24 @@ public:
                                        XrdCl::ResponseHandler   *handler,
                                        timeout_t                 timeout) override;
 
+    virtual XrdCl::XRootDStatus MkDir(const std::string        &path,
+                                      XrdCl::MkDirFlags::Flags  flags,
+                                      XrdCl::Access::Mode       mode,
+                                      XrdCl::ResponseHandler   *handler,
+                                      timeout_t                 timeout) override;
+
     virtual XrdCl::XRootDStatus Query(XrdCl::QueryCode::Code  queryCode,
                                       const XrdCl::Buffer     &arg,
                                       XrdCl::ResponseHandler  *handler,
                                       timeout_t                timeout) override;
+
+    virtual XrdCl::XRootDStatus Rm(const std::string      &path,
+                                   XrdCl::ResponseHandler *handler,
+                                   timeout_t               timeout) override;
+
+    virtual XrdCl::XRootDStatus RmDir(const std::string      &path,
+                                      XrdCl::ResponseHandler *handler,
+                                      timeout_t               timeout) override;
 
     virtual bool SetProperty(const std::string &name,
                              const std::string &value) override;

--- a/src/XrdClS3/S3Filesystem.hh
+++ b/src/XrdClS3/S3Filesystem.hh
@@ -104,7 +104,7 @@ private:
     std::unordered_map<std::string, std::string> m_properties;
 
     // Protects the m_properties data from concurrent access
-    std::mutex m_properties_mutex;
+    mutable std::mutex m_properties_mutex;
 
     // Protects the m_handles data from concurrent access
     std::shared_mutex m_handles_mutex;

--- a/tests/XrdClS3/CMakeLists.txt
+++ b/tests/XrdClS3/CMakeLists.txt
@@ -7,6 +7,7 @@ include( GoogleTest )
 
 add_executable( xrdcl-s3-test
   ReadTest.cc
+  DeleteTest.cc
   DirListTest.cc
 )
 

--- a/tests/XrdClS3/DeleteTest.cc
+++ b/tests/XrdClS3/DeleteTest.cc
@@ -1,0 +1,44 @@
+/****************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "../common/TransferTest.hh"
+
+#include <XrdCl/XrdClFileSystem.hh>
+
+class S3DeleteFixture : public TransferFixture {};
+
+TEST_F(S3DeleteFixture, Test)
+{
+    std::string fname = "/test-bucket/delete_file";
+    auto url = GetCacheURL() + fname;
+    WritePattern(url, 8, 'a', 2);
+    XrdCl::FileSystem fs(GetCacheURL());
+
+    XrdCl::StatInfo *response{nullptr};
+    auto st = fs.Stat(fname + "?authz=" + GetReadToken(), response, 10);
+    ASSERT_TRUE(st.IsOK()) << "Failed to stat new file: " << st.ToString();
+    delete response;
+
+    st = fs.Rm(fname + "?authz=" + GetWriteToken(), 10);
+    ASSERT_TRUE(st.IsOK()) << "Failed to remove file: " << st.ToString();
+
+    response = nullptr;
+    st = fs.Stat(fname + "?authz=" + GetReadToken(), response, 10);
+    ASSERT_FALSE(st.IsOK()) << "Stat of removed file should have failed";
+    ASSERT_EQ(st.errNo, kXR_NotFound);
+}


### PR DESCRIPTION
- Mkdir
- Rm and Rmdir
- Get/Set properties

Additionally, as part of `mkdir`, this implements the ability to do the write of a zero-sized object.