### PR TITLE
Use XrdCl::QueryCode::Head to retrieve cache control values

### DIFF
--- a/src/XrdClCurl/CurlFile.cc
+++ b/src/XrdClCurl/CurlFile.cc
@@ -491,7 +491,7 @@ File::Fcntl(const XrdCl::Buffer &arg, XrdCl::ResponseHandler *handler,
     try
     {
         XrdCl::QueryCode::Code code = (XrdCl::QueryCode::Code)std::stoi(as);
-        if (code == XrdCl::QueryCode::XAttr)
+        if (code == XrdCl::QueryCode::Head)
         {
             nlohmann::json xatt;
             std::string etagRes;
@@ -516,7 +516,6 @@ File::Fcntl(const XrdCl::Buffer &arg, XrdCl::ResponseHandler *handler,
                         {
                             std::string sa = cc.substr(fm, i);
                             long int a = std::stol(sa);
-                            // time_t t = time(NULL) + a;
                             xatt["max-age"] = a;
                             break;
                         }
@@ -524,7 +523,7 @@ File::Fcntl(const XrdCl::Buffer &arg, XrdCl::ResponseHandler *handler,
                 }
             }
             XrdCl::Buffer *respBuff = new XrdCl::Buffer();
-            m_logger->Debug(kLogXrdClCurl, "Fcntl conent %s", xatt.dump().c_str());
+            m_logger->Debug(kLogXrdClCurl, "Fcntl content %s", xatt.dump().c_str());
             respBuff->FromString(xatt.dump());
             obj->Set(respBuff);
         }

--- a/src/XrdClCurl/CurlFile.cc
+++ b/src/XrdClCurl/CurlFile.cc
@@ -516,8 +516,8 @@ File::Fcntl(const XrdCl::Buffer &arg, XrdCl::ResponseHandler *handler,
                         {
                             std::string sa = cc.substr(fm, i);
                             long int a = std::stol(sa);
-                            time_t t = time(NULL) + a;
-                            xatt["expire"] = t;
+                            // time_t t = time(NULL) + a;
+                            xatt["max-age"] = a;
                             break;
                         }
                     }

--- a/src/XrdClCurl/CurlFile.hh
+++ b/src/XrdClCurl/CurlFile.hh
@@ -79,6 +79,11 @@ public:
                                     XrdCl::ResponseHandler *handler,
                                     timeout_t               timeout) override;
 
+    virtual XrdCl::XRootDStatus Fcntl(XrdCl::QueryCode::Code queryCode,
+                                    const XrdCl::Buffer     &arg,
+                                    XrdCl::ResponseHandler  *handler,
+                                    timeout_t                timeout) override;
+
     virtual XrdCl::XRootDStatus Fcntl(const XrdCl::Buffer    &arg,
                                     XrdCl::ResponseHandler *handler,
                                     timeout_t               timeout) override;

--- a/src/XrdClCurl/CurlFilesystem.cc
+++ b/src/XrdClCurl/CurlFilesystem.cc
@@ -194,7 +194,7 @@ XrdCl::XRootDStatus Filesystem::Query(XrdCl::QueryCode::Code  queryCode,
             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errOSError);
         }
     }
-    else if (queryCode == XrdCl::QueryCode::Head)
+    else if (queryCode == XrdCl::QueryCode::FSInfo)
     {
         std::string path = arg.ToString();
         m_logger->Debug(kLogXrdClCurl, "XrdClCurl::Filesystem::Query cache control: file system url %s, path %s", m_url.GetURL().c_str(), path.c_str());

--- a/src/XrdClCurl/CurlFilesystem.cc
+++ b/src/XrdClCurl/CurlFilesystem.cc
@@ -158,10 +158,10 @@ XrdCl::XRootDStatus Filesystem::Query(XrdCl::QueryCode::Code  queryCode,
     timeout_t                timeout)
 {
     auto ts = XrdClCurl::Factory::GetHeaderTimeoutWithDefault(timeout);
+    auto url = GetCurrentURL(arg.ToString());
 
     if (queryCode == XrdCl::QueryCode::Checksum)
     {
-        auto url = GetCurrentURL(arg.ToString());
         m_logger->Debug(kLogXrdClCurl, "XrdClCurl::Filesystem::Query checksum path %s", url.c_str());
 
         XrdClCurl::ChecksumType preferred = XrdClCurl::ChecksumType::kCRC32C;
@@ -196,11 +196,10 @@ XrdCl::XRootDStatus Filesystem::Query(XrdCl::QueryCode::Code  queryCode,
     }
     else if (queryCode == XrdCl::QueryCode::FSInfo)
     {
-        std::string path = arg.ToString();
-        m_logger->Debug(kLogXrdClCurl, "XrdClCurl::Filesystem::Query cache control: file system url %s, path %s", m_url.GetURL().c_str(), path.c_str());
+        m_logger->Debug(kLogXrdClCurl, "XrdClCurl::Filesystem::Query cache control: file system url %s, path %s", m_url.GetURL().c_str(), url.c_str());
         std::unique_ptr<CurlQueryOp> queryOp(
             new CurlQueryOp(
-                handler, path, ts, m_logger,SendResponseInfo(),
+                handler, url, ts, m_logger,SendResponseInfo(),
                 GetConnCallout(), queryCode, m_header_callout.load(std::memory_order_acquire)
             )
         );

--- a/src/XrdClCurl/CurlFilesystem.cc
+++ b/src/XrdClCurl/CurlFilesystem.cc
@@ -194,12 +194,10 @@ XrdCl::XRootDStatus Filesystem::Query(XrdCl::QueryCode::Code  queryCode,
             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errOSError);
         }
     }
-    else if (queryCode == XrdCl::QueryCode::XAttr)
+    else if (queryCode == XrdCl::QueryCode::Head)
     {
         std::string path = arg.ToString();
-        std::string full_url = m_url.GetURL();
-        m_logger->Debug(kLogXrdClCurl, "XrdClCurl::Filesystem::Query xattr full_url %s, path %s", full_url.c_str(), path.c_str());
-        full_url = m_url.GetURL();
+        m_logger->Debug(kLogXrdClCurl, "XrdClCurl::Filesystem::Query cache control: file system url %s, path %s", m_url.GetURL().c_str(), path.c_str());
         std::unique_ptr<CurlQueryOp> queryOp(
             new CurlQueryOp(
                 handler, path, ts, m_logger,SendResponseInfo(),

--- a/src/XrdClCurl/CurlQuery.cc
+++ b/src/XrdClCurl/CurlQuery.cc
@@ -27,7 +27,7 @@ void CurlQueryOp::Success()
     SetDone(false);
     m_logger->Debug(kLogXrdClCurl, "CurlQueryOp::Success");
 
-    if (m_queryCode == XrdCl::QueryCode::Head) {
+    if (m_queryCode == XrdCl::QueryCode::FSInfo) {
         XrdCl::Buffer *qInfo = new XrdCl::Buffer();
         qInfo->FromString(m_headers.GetETag());
         auto obj = new XrdCl::AnyObject();

--- a/src/XrdClCurl/CurlQuery.cc
+++ b/src/XrdClCurl/CurlQuery.cc
@@ -27,7 +27,7 @@ void CurlQueryOp::Success()
     SetDone(false);
     m_logger->Debug(kLogXrdClCurl, "CurlQueryOp::Success");
 
-    if (m_queryCode == XrdCl::QueryCode::XAttr) {
+    if (m_queryCode == XrdCl::QueryCode::Head) {
         XrdCl::Buffer *qInfo = new XrdCl::Buffer();
         qInfo->FromString(m_headers.GetETag());
         auto obj = new XrdCl::AnyObject();

--- a/src/XrdClPelican/PelicanFile.cc
+++ b/src/XrdClPelican/PelicanFile.cc
@@ -217,7 +217,7 @@ File::Open(const std::string      &url,
     }
 
     auto ts = GetHeaderTimeout(timeout);
-    m_logger->Debug(kLogXrdClPelican, "Opening %s (with timeout %d)", m_url.c_str(), timeout);
+    m_logger->Debug(kLogXrdClPelican, "Opening %s (with timeout %ld)", m_url.c_str(), timeout);
 
     std::unique_ptr<XrdCl::ResponseHandler> wrapped_handler(
         new DirectorCacheResponseHandler<XrdClCurl::OpenResponseInfo, XrdClCurl::OpenResponseInfo>(

--- a/src/XrdClS3/S3Factory.hh
+++ b/src/XrdClS3/S3Factory.hh
@@ -40,8 +40,8 @@ public:
     virtual ~Factory() {}
     Factory(const Factory &) = delete;
 
-    virtual XrdCl::FilePlugIn *CreateFile(const std::string &url) override;
-    virtual XrdCl::FileSystemPlugIn *CreateFileSystem(const std::string &url) override;
+    virtual XrdCl::FilePlugIn *CreateFile(const std::string &url);
+    virtual XrdCl::FileSystemPlugIn *CreateFileSystem(const std::string &url);
 
     // Given a S3-style url (s3://bucket/object), return the corresponding HTTPS URL.
     //

--- a/src/XrdClS3/S3File.hh
+++ b/src/XrdClS3/S3File.hh
@@ -44,53 +44,53 @@ public:
     virtual ~File() noexcept;
 
     virtual XrdCl::XRootDStatus Close(XrdCl::ResponseHandler *handler,
-                                     timeout_t                timeout) override;
+                                     timeout_t                timeout);
 
     virtual bool GetProperty( const std::string &name,
-                            std::string &value ) const override;
+                            std::string &value ) const;
 
-    virtual bool IsOpen() const override;
+    virtual bool IsOpen() const;
 
     virtual XrdCl::XRootDStatus Open(const std::string      &url,
                                      XrdCl::OpenFlags::Flags flags,
                                      XrdCl::Access::Mode     mode,
                                      XrdCl::ResponseHandler *handler,
-                                     timeout_t               timeout) override;
+                                     timeout_t               timeout);
 
     virtual XrdCl::XRootDStatus PgRead(uint64_t                offset,
                                        uint32_t                size,
                                        void                   *buffer,
                                        XrdCl::ResponseHandler *handler,
-                                       timeout_t               timeout) override;
+                                       timeout_t               timeout);
 
     virtual XrdCl::XRootDStatus Read(uint64_t                offset,
                                      uint32_t                size,
                                      void                   *buffer,
                                      XrdCl::ResponseHandler *handler,
-                                     timeout_t               timeout) override;
+                                     timeout_t               timeout);
 
     virtual bool SetProperty( const std::string &name,
-                            const std::string &value ) override;
+                            const std::string &value );
 
     virtual XrdCl::XRootDStatus Stat(bool                    force,
                                      XrdCl::ResponseHandler *handler,
-                                     timeout_t               timeout) override;
+                                     timeout_t               timeout);
 
     virtual XrdCl::XRootDStatus VectorRead(const XrdCl::ChunkList &chunks,
                                            void                   *buffer,
                                            XrdCl::ResponseHandler *handler,
-                                           timeout_t               timeout ) override;
+                                           timeout_t               timeout );
 
     virtual XrdCl::XRootDStatus Write(uint64_t            offset,
                                   uint32_t                size,
                                   const void             *buffer,
                                   XrdCl::ResponseHandler *handler,
-                                  timeout_t               timeout) override;
+                                  timeout_t               timeout);
 
     virtual XrdCl::XRootDStatus Write(uint64_t             offset,
                                   XrdCl::Buffer          &&buffer,
                                   XrdCl::ResponseHandler  *handler,
-                                  timeout_t                timeout) override;
+                                  timeout_t                timeout);
 
 private:
     bool m_is_opened{false};
@@ -118,7 +118,7 @@ private:
 
         virtual std::shared_ptr<HeaderList> GetHeaders(const std::string &verb,
                                                        const std::string &url,
-                                                       const HeaderList &headers) override;
+                                                       const HeaderList &headers);
 
     private:
         File &m_parent;

--- a/src/XrdClS3/S3Filesystem.hh
+++ b/src/XrdClS3/S3Filesystem.hh
@@ -51,41 +51,41 @@ public:
     virtual XrdCl::XRootDStatus DirList(const std::string          &path,
                                         XrdCl::DirListFlags::Flags  flags,
                                         XrdCl::ResponseHandler     *handler,
-                                        timeout_t                   timeout) override;
+                                        timeout_t                   timeout);
 
     virtual bool GetProperty(const std::string &name,
-                             std::string       &value) const override;
+                             std::string       &value) const;
 
     virtual XrdCl::XRootDStatus Locate(const std::string        &path,
                                        XrdCl::OpenFlags::Flags   flags,
                                        XrdCl::ResponseHandler   *handler,
-                                       timeout_t                 timeout) override;
+                                       timeout_t                 timeout);
 
     virtual XrdCl::XRootDStatus MkDir(const std::string        &path,
                                       XrdCl::MkDirFlags::Flags  flags,
                                       XrdCl::Access::Mode       mode,
                                       XrdCl::ResponseHandler   *handler,
-                                      timeout_t                 timeout) override;
+                                      timeout_t                 timeout);
 
     virtual XrdCl::XRootDStatus Query(XrdCl::QueryCode::Code  queryCode,
                                       const XrdCl::Buffer     &arg,
                                       XrdCl::ResponseHandler  *handler,
-                                      timeout_t                timeout) override;
+                                      timeout_t                timeout);
 
     virtual XrdCl::XRootDStatus Rm(const std::string      &path,
                                    XrdCl::ResponseHandler *handler,
-                                   timeout_t               timeout) override;
+                                   timeout_t               timeout);
 
     virtual XrdCl::XRootDStatus RmDir(const std::string      &path,
                                       XrdCl::ResponseHandler *handler,
-                                      timeout_t               timeout) override;
+                                      timeout_t               timeout);
 
     virtual bool SetProperty(const std::string &name,
-                             const std::string &value) override;
+                             const std::string &value);
 
     virtual XrdCl::XRootDStatus Stat(const std::string      &path,
                                      XrdCl::ResponseHandler *handler,
-                                     timeout_t               timeout) override;
+                                     timeout_t               timeout);
 
 private:
     // State indicating whether the file is open.
@@ -122,7 +122,7 @@ private:
 
         virtual std::shared_ptr<HeaderList> GetHeaders(const std::string &verb,
                                                        const std::string &url,
-                                                       const HeaderList &headers) override;
+                                                       const HeaderList &headers);
 
     private:
         Filesystem &m_parent;


### PR DESCRIPTION
@bbockelm @osschar

Do not merge this PR!
The new query code for cache control parameters is in my local repository.
The change is dependent to https://github.com/alja/xrootd/pull/89