### PR TITLE
Release locks that are not necessary.

### DIFF
--- a/src/XrdClCurl/XrdClCurlFile.cc
+++ b/src/XrdClCurl/XrdClCurlFile.cc
@@ -675,6 +675,7 @@ File::ReadPrefetch(uint64_t offset, uint64_t size, void *buffer, XrdCl::Response
                 GetConnCallout(), &m_default_header_callout
             )
         );
+        lock.unlock();
         try {
             m_queue->Produce(m_prefetch_op);
         } catch (...) {

--- a/src/XrdClCurl/XrdClCurlUtil.cc
+++ b/src/XrdClCurl/XrdClCurlUtil.cc
@@ -674,6 +674,7 @@ HandlerQueue::Produce(std::shared_ptr<CurlOperation> handler)
         [&]{return m_ops.size() < m_max_pending_ops;}
     );
     if (std::chrono::steady_clock::now() > handler_expiry) {
+        lk.unlock();
         handler->Fail(XrdCl::errOperationExpired, 0, "Operation expired while waiting for worker");
         return;
     }


### PR DESCRIPTION
Particularly, the lock is held across the call to `Fail`, the response handler can try to acquire additional locks.  This was observed to cause a deadlock for the prefetch code as the prefetch lock was held when the queue's mutex was acquire (a classic deadlock scenario).