### PR TITLE
Automatically bump the version in user-agent

### DIFF
--- a/.github/workflows/RPM.yml
+++ b/.github/workflows/RPM.yml
@@ -1,0 +1,112 @@
+name: RPM
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+      - v*
+  push:
+    branches:
+      - main
+      - v*
+    paths-ignore:
+      - .gitignore
+      - '**.md'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  alma9:
+    name: Alma Linux 9
+    runs-on: ubuntu-latest
+    container: almalinux:9
+
+    steps:
+    - name: Install git
+      run: yum install -y git
+
+    - name: Clone repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install RPM development tools
+      run: |
+        dnf install -y epel-release rpmdevtools dnf-plugins-core
+        dnf config-manager --set-enabled crb
+
+    - name: Install XRootD build dependencies
+      run: dnf builddep -y rpm/xrdcl-pelican.spec
+
+    - name: Build RPMs
+      shell: bash
+      run: |
+        rpmdev-setuptree
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        export XRDCL_VERSION=$(grep Version rpm/xrdcl-pelican.spec | cut -f 2 -d ' ')
+        git archive --prefix xrdcl-pelican-$XRDCL_VERSION/ -o $(rpm -E '%{_sourcedir}')/xrdcl-pelican-$XRDCL_VERSION.tar.gz HEAD
+        rpmbuild -bb --with git rpm/xrdcl-pelican.spec
+
+    - name: Install RPMs
+      run: dnf install -y $(rpm -E '%{_rpmdir}')/*/*.rpm
+
+    - name: Move RPMs to Artifact Directory
+      run: mkdir RPMS && mv $(rpm -E '%{_rpmdir}')/ RPMS$(rpm -E '%{dist}' | tr . /)
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: alma9
+        path: RPMS
+        retention-days: 14
+
+  alma10beta:
+    name: Alma Linux 10
+    runs-on: ubuntu-latest
+    container: almalinux:10
+
+    steps:
+    - name: Install git
+      run: yum install -y git
+
+    - name: Clone repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Install RPM development tools
+      run: |
+        dnf install -y epel-release rpmdevtools dnf-plugins-core
+        dnf config-manager --set-enabled crb
+
+    - name: Install XRootD build dependencies
+      run: dnf builddep -y rpm/xrdcl-pelican.spec
+
+    - name: Build RPMs
+      shell: bash
+      run: |
+        rpmdev-setuptree
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        export XRDCL_VERSION=$(grep Version rpm/xrdcl-pelican.spec | cut -f 2 -d ' ')
+        git archive --prefix xrdcl-pelican-$XRDCL_VERSION/ -o $(rpm -E '%{_sourcedir}')/xrdcl-pelican-$XRDCL_VERSION.tar.gz HEAD
+        rpmbuild -bb --with git rpm/xrdcl-pelican.spec
+
+    - name: Install RPMs
+      run: dnf install -y $(rpm -E '%{_rpmdir}')/*/*.rpm
+
+    - name: Move RPMs to Artifact Directory
+      run: mkdir RPMS && mv $(rpm -E '%{_rpmdir}')/ RPMS$(rpm -E '%{dist}' | tr . /)
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: alma10
+        path: RPMS
+        retention-days: 14

--- a/.github/workflows/RPM.yml
+++ b/.github/workflows/RPM.yml
@@ -23,6 +23,26 @@ concurrency:
 
 jobs:
 
+  version:
+    name: Specfile Version check
+    runs-on: ubuntu-latest
+    if: github.ref_type != 'tag'
+
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v4
+    - name: Check RPM specfile version
+      run: |
+        export RPM_VERSION="v$(grep Version rpm/xrdcl-pelican.spec | cut -f 2 -d ' ')"
+        if git tag | grep -q $RPM_VERSION; then
+          echo "Version in rpm/xrdcl-pelican.spec currently is set to $RPM_VERSION"
+          echo "This is an existing tag in the repository.  The RPM specfile on a branch"
+          echo "must always point at the next release"
+          echo "Known tags:"
+          git tag
+          exit 1
+        fi
+
   alma9:
     name: Alma Linux 9
     runs-on: ubuntu-latest

--- a/.github/workflows/RPM.yml
+++ b/.github/workflows/RPM.yml
@@ -12,6 +12,9 @@ on:
     branches:
       - main
       - v*
+    tags:
+      - v[0-9]+\.[0-9]+\.[0-9]+
+      - v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+
     paths-ignore:
       - .gitignore
       - '**.md'
@@ -48,6 +51,9 @@ jobs:
     runs-on: ubuntu-latest
     container: almalinux:9
 
+    outputs:
+      artifact-id: ${{ steps.upload.outputs.artifact-id }}
+
     steps:
     - name: Install git
       run: yum install -y git
@@ -81,16 +87,20 @@ jobs:
       run: mkdir RPMS && mv $(rpm -E '%{_rpmdir}')/ RPMS$(rpm -E '%{dist}' | tr . /)
 
     - name: Upload Artifacts
+      id: upload
       uses: actions/upload-artifact@v4
       with:
         name: alma9
         path: RPMS
         retention-days: 14
 
-  alma10beta:
+  alma10:
     name: Alma Linux 10
     runs-on: ubuntu-latest
     container: almalinux:10
+
+    outputs:
+      artifact-id: ${{ steps.upload.outputs.artifact-id }}
 
     steps:
     - name: Install git
@@ -126,7 +136,55 @@ jobs:
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
+      id: upload
       with:
         name: alma10
         path: RPMS
         retention-days: 14
+
+  release:
+    name: Create draft release on tag
+    runs-on: ubuntu-latest
+    container: almalinux:10
+    needs: [alma10, alma9]
+    if: github.ref_type == 'tag'
+
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Download Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        artifact-ids: ${{ needs.alma9.outputs.artifact-id }}, ${{ needs.alma10.outputs.artifact-id }}
+
+    - name: Generate changelog
+      shell: bash
+      run: |
+        rpm -qp --changelog alma9/el9/x86_64/xrdcl-pelican-debuginfo*.el9.* | while IFS= read -r line; do if [ -z "$line" ]; then break; fi; echo "$line"; done > CHANGELOG.txt
+
+        export XRDCL_VERSION=$(rpm -qp alma9/el9/x86_64/xrdcl-pelican-debuginfo*.el9.* --queryformat '%{VERSION}')
+        echo "RPM version detected: $XRDCL_VERSION"
+        if [ "$GITHUB_REF_NAME" != "v$XRDCL_VERSION" ]; then
+          echo "The github tag name ($GITHUB_REF_NAME) does not match the RPM version (v$XRDCL_VERSION)"
+          exit 1
+        fi
+
+        if ! head -n 1 CHANGELOG.txt | grep -q $XRDCL_VERSION; then
+          echo "The changelog entry in the produced RPM does not match the RPM version ($XRDCL_VERSION)"
+          exit 1
+        fi
+        tail -n +2 CHANGELOG.txt > CHANGELOG.txt.new
+        mv CHANGELOG.txt.new CHANGELOG.txt
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: "alma9/el9/x86_64/*.rpm, alma10/el10/x86_64/*.rpm"
+        tag_name: ${{ github.ref_name }}
+        body_path: CHANGELOG.txt
+        draft: true
+        fail_on_unmatched_files: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,29 @@ public:
 int main(void) {return 0;}"
 HAVE_XRDCL_IFACE6)
 
+#
+# Generate a reasonable version string to use
+#
+if( NOT DEFINED XrdClCurl_VERSION_STRING )
+  set( XrdClCurl_VERSION_STRING "devel" )
+endif()
+
+if( XrdClCurl_VERSION_STRING MATCHES "devel" AND IS_DIRECTORY ${PROJECT_SOURCE_DIR}/.git )
+  find_package( Git QUIET )
+  if( Git_FOUND )
+    message( VERBOSE "Determining version with git" )
+    execute_process( COMMAND
+      ${GIT_EXECUTABLE} --git-dir ${PROJECT_SOURCE_DIR}/.git describe --tags
+      OUTPUT_VARIABLE XrdClCurl_VERSION_STRING ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE )
+    set( XrdClCurl_VERSION_STRING "${XrdClCurl_VERSION_STRING}" CACHE INTERNAL "XrdClCurl version" )
+  endif()
+endif()
+
+#
+# Generate the correct version information
+#
+configure_file(src/XrdClCurl/XrdClCurlVersion.hh.in src/XrdClCurl/XrdClCurlVersion.hh)
+
 add_library(XrdClPelicanObj OBJECT
   src/common/XrdClCurlResponseInfo.hh              src/common/XrdClCurlResponses.hh
   src/common/XrdClCurlParseTimeout.cc              src/common/XrdClCurlParseTimeout.hh
@@ -134,6 +157,7 @@ add_library(XrdClPelicanObj OBJECT
   src/XrdClPelican/PelicanFilesystem.cc            src/XrdClPelican/PelicanFilesystem.hh
   src/XrdClPelican/PelicanHeaders.cc               src/XrdClPelican/PelicanHeaders.hh
 )
+target_include_directories( XrdClPelicanObj PUBLIC ${PROJECT_BINARY_DIR}/src )
 
 add_library(XrdClCurlObj OBJECT
   src/common/XrdClCurlParseTimeout.cc    src/common/XrdClCurlParseTimeout.hh
@@ -158,6 +182,8 @@ add_library(XrdClCurlObj OBJECT
   src/XrdClCurl/XrdClCurlOptionsCache.cc src/XrdClCurl/XrdClCurlOptionsCache.hh
   src/XrdClCurl/XrdClCurlUtil.cc         src/XrdClCurl/XrdClCurlUtil.hh
 )
+# Makes the generated XrdClCurlVersion.hh in the include path
+target_include_directories( XrdClCurlObj PUBLIC ${PROJECT_BINARY_DIR}/src/XrdClCurl )
 
 add_library( XrdClS3Obj OBJECT
   src/XrdClS3/XrdClS3DownloadHandler.cc src/XrdClS3/XrdClS3DownloadHandler.hh

--- a/rpm/xrdcl-pelican.spec
+++ b/rpm/xrdcl-pelican.spec
@@ -70,10 +70,10 @@ Requires: xrootd-client <  1:%{xrootd_next_major}.0.0-1
 %endif
 
 %if 0%{?rhel} >= 9
-%cmake3 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DXROOTD_EXTERNAL_TINYXML2=1 -DXROOTD_EXTERNAL_JSON=1 .
+%cmake3 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DXROOTD_EXTERNAL_TINYXML2=1 -DXROOTD_EXTERNAL_JSON=1 -DXrdClCurl_VERSION_STRING=%{version} .
 %else
 cp %{SOURCE1} cmake/tinyxml2/
-%cmake3 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DXROOTD_EXTERNAL_JSON=1 .
+%cmake3 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DXROOTD_EXTERNAL_JSON=1 -DXrdClCurl_VERSION_STRING=%{version} .
 %endif
 make VERBOSE=1 %{?_smp_mflags}
 

--- a/rpm/xrdcl-pelican.spec
+++ b/rpm/xrdcl-pelican.spec
@@ -1,6 +1,6 @@
 
 Name: xrdcl-pelican
-Version: 1.5.1
+Version: 1.5.2
 Release: 1%{?dist}
 Summary: A Pelican-specific backend for the XRootD client
 
@@ -89,6 +89,10 @@ make install DESTDIR=$RPM_BUILD_ROOT
 %{_sysconfdir}/xrootd/client.plugins.d/s3-plugin.conf
 
 %changelog
+* Sun Aug 24 2025 Brian Bockelman <bbockelman@morgridge.org> 1.5.2-1
+- Add infrastructure for automating GitHub releases from a pushed tag
+- Automatically build as part of a release.
+
 * Tue Aug 12 2025 Mátyás Selmeci <mselmeci@wisc.edu> 1.5.1-1
 - Add extensive statistics about the performance of the XrdClCurl client
 

--- a/rpm/xrdcl-pelican.spec
+++ b/rpm/xrdcl-pelican.spec
@@ -136,7 +136,7 @@ make install DESTDIR=$RPM_BUILD_ROOT
 - Fix the returned stat flags
 - Fix uninitialized read when using the broker
 
-* Tue Feb 5 2025 Brian Bockelman <bbockelman@morgridge.org> - 1.0.5-1
+* Wed Feb 5 2025 Brian Bockelman <bbockelman@morgridge.org> - 1.0.5-1
 - Fix build failures with some compilers.
 
 * Tue Feb 4 2025 Brian Bockelman <bbockelman@morgridge.org> - 1.0.4-1

--- a/src/XrdClCurl/XrdClCurlUtil.cc
+++ b/src/XrdClCurl/XrdClCurlUtil.cc
@@ -20,6 +20,7 @@
 #include "XrdClCurlOps.hh"
 #include "XrdClCurlOptionsCache.hh"
 #include "XrdClCurlUtil.hh"
+#include "XrdClCurlVersion.hh"
 #include "XrdClCurlWorker.hh"
 
 #include <XProtocol/XProtocol.hh>
@@ -605,7 +606,7 @@ XrdClCurl::GetHandle(bool verbose) {
         return result;
     }
 
-    curl_easy_setopt(result, CURLOPT_USERAGENT, "xrdcl-curl/1.5.1");
+    curl_easy_setopt(result, CURLOPT_USERAGENT, "xrdcl-curl/" XrdClCurlVERSION);
     curl_easy_setopt(result, CURLOPT_DEBUGFUNCTION, DumpHeader);
     if (verbose)
         curl_easy_setopt(result, CURLOPT_VERBOSE, 1L);

--- a/src/XrdClCurl/XrdClCurlVersion.hh.in
+++ b/src/XrdClCurl/XrdClCurlVersion.hh.in
@@ -1,0 +1,20 @@
+/***************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#define XrdClCurlVERSION  "@XrdClCurl_VERSION_STRING@"
+

--- a/src/XrdClPelican/FedInfo.cc
+++ b/src/XrdClPelican/FedInfo.cc
@@ -18,6 +18,7 @@
 
 #include "FedInfo.hh"
 #include "PelicanFilesystem.hh"
+#include "XrdClCurl/XrdClCurlVersion.hh"
 
 #include <nlohmann/json.hpp>
 #include <curl/curl.h>
@@ -54,7 +55,7 @@ CURL *GetHandle(bool verbose) {
         return result;
     }
 
-    curl_easy_setopt(result, CURLOPT_USERAGENT, "xrdcl-pelican/1.5.1");
+    curl_easy_setopt(result, CURLOPT_USERAGENT, "xrdcl-pelican/" XrdClCurlVERSION);
     curl_easy_setopt(result, CURLOPT_DEBUGFUNCTION, DumpHeader);
     if (verbose)
         curl_easy_setopt(result, CURLOPT_VERBOSE, 1L);


### PR DESCRIPTION
By default, this will set a version from the git tag (or, failing that, "devel").  Will use the RPM version number for spec builds as well.