### PR TITLE
Lift DNS requirement for connection callback

### DIFF
--- a/src/XrdClCurl/XrdClCurlUtil.cc
+++ b/src/XrdClCurl/XrdClCurlUtil.cc
@@ -1205,6 +1205,9 @@ CurlWorker::Run() {
                 broker_reqs.erase(entry.first);
                 m_conncall_timeout.fetch_add(1, std::memory_order_relaxed);
             }
+
+            // Cleanup the fake connection cache entries.
+            XrdClCurl::CurlOperation::CleanupDnsCache();
         }
 
         waitfds.clear();

--- a/tests/XrdClCurl/curl-setup.sh
+++ b/tests/XrdClCurl/curl-setup.sh
@@ -103,6 +103,11 @@ emailAddress           = optional
 basicConstraints = critical,CA:false
 keyUsage = digitalSignature, keyEncipherment
 extendedKeyUsage = critical, serverAuth, clientAuth
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+DNS.2 = blah-cache.example.com
 
 EOF
 


### PR DESCRIPTION
This PR removes the requirement for successful DNS resolution from the connection callback framework, allowing URLs to include internal / non-Internet hostnames.

Additionally, this fixes an issue where the callback failure for the OPTIONS verb caused the parent operation to never complete.