### PR TITLE
Allow client to query for caches, not origins

### DIFF
--- a/src/XrdClPelican/DirectorCache.hh
+++ b/src/XrdClPelican/DirectorCache.hh
@@ -128,6 +128,26 @@ public:
         m_root.Expire(now);
     }
 
+    void Reset() const {
+        const std::unique_lock sentry(m_mutex);
+
+        m_root = CacheEntry(std::chrono::steady_clock::now());
+    }
+
+    static void ResetAll() {
+        std::vector<DirectorCache*> dcache;
+        {
+            std::shared_lock read_guard(m_caches_lock);
+            dcache.reserve(m_caches.size());
+            for (const auto &entry : m_caches) {
+                dcache.push_back(entry.second.get());
+            }
+        }
+        for (auto &entry : dcache) {
+            entry->Reset();
+        }
+    }
+
 private:
 
     DirectorCache(const std::chrono::steady_clock::time_point &now);

--- a/src/XrdClPelican/FedInfo.hh
+++ b/src/XrdClPelican/FedInfo.hh
@@ -43,6 +43,10 @@ class FederationInfo;
 // Manages lookup of federation metadata and a corresponding cache
 class FederationFactory final {
 public:
+    // Federation factory is not copyable or movable
+    FederationFactory(const FederationFactory &) = delete;
+    FederationFactory(FederationFactory &&) = delete;
+
     // Returns the singleton instance of the federation factory.
     static FederationFactory &GetInstance(XrdCl::Log &logger, const struct timespec &fed_timeout);
 

--- a/src/XrdClPelican/PelicanFile.cc
+++ b/src/XrdClPelican/PelicanFile.cc
@@ -210,7 +210,12 @@ File::Open(const std::string      &url,
         if (!info->IsValid()) {
             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidAddr, 0, "Failed to look up pelican metadata: " + err);
         }
-        m_url = info->GetDirector() + "/api/v1.0/director/origin/" + pelican_url.GetPathWithParams();
+        if (Pelican::Filesystem::GetDirectoryQueryMode() == Pelican::Filesystem::DirectoryQuery::Cache) {
+            m_url = "/";
+        } else {
+            m_url = "/api/v1.0/director/origin/";
+        }
+        m_url = info->GetDirector() + m_url + pelican_url.GetPathWithParams();
     } else {
         m_logger->Debug(kLogXrdClPelican, "Using cached origin URL %s", m_url.c_str());
         dcache = nullptr;

--- a/src/XrdClPelican/PelicanFilesystem.hh
+++ b/src/XrdClPelican/PelicanFilesystem.hh
@@ -22,6 +22,7 @@
 #include <XrdCl/XrdClPlugInInterface.hh>
 #include <XrdCl/XrdClURL.hh>
 
+#include <atomic>
 #include <string>
 #include <unordered_map>
 
@@ -80,8 +81,26 @@ public:
     // Set the cache token value
     static void SetCacheToken(const std::string &token);
 
+    // Directory query modes
+    enum class DirectoryQuery {
+        Origin, // Always use origin
+        Cache   // Always use cache
+    };
+
+    // Set the directory query mode
+    static void SetDirectoryQueryMode(DirectoryQuery mode) {
+        s_directory_query.store(mode, std::memory_order_relaxed);
+    }
+
+    // Get the current directory query mode
+    static DirectoryQuery GetDirectoryQueryMode() {
+        return s_directory_query.load(std::memory_order_relaxed);
+    }
+
 private:
     XrdCl::XRootDStatus ConstructURL(const std::string &oper, const std::string &path, timeout_t timeout, std::string &full_url, XrdCl::FileSystem *&http_fs, const DirectorCache *&dcache, struct timespec &ts);
+
+    static std::atomic<DirectoryQuery> s_directory_query;
 
     XrdCl::Log *m_logger{nullptr};
 

--- a/src/XrdClPelican/README.md
+++ b/src/XrdClPelican/README.md
@@ -1,0 +1,38 @@
+XrdCl Plugin for the `pelican://` protocol
+==========================================
+
+The `XrdClPelican` plugin provides an implementation of the `pelican://`
+protocol used by the [Pelican Platfrom](https://pelicanplatform.org).
+
+The `pelican://` protocol is based on HTTPS (the implementation internally
+leverages `XrdClCurl`) and provides the following functionality:
+
+- Service discovery protocol allowing the central director service to be
+  located separately from the metadata lookup.
+- Checksum lookup caching on the client-side
+- Origin selection cache, allowing the client to skip the director queries
+  if it's recently been sent to an origin serving the same namespace.
+- Connection brokering functionality, allowing the downloading from
+  origins that have no incoming connectivity.
+
+Configuration
+-------------
+
+An installed plugin will automatically enable itself for the `pelican://`
+protocol.  The following environment variables control the client configuration
+(the corresponding C++ API configuration names are given parenthetically):
+
+- `XRD_PELICANBROKERSOCKET` (`PelicanBrokerSocket`): The location of the Unix
+  domain socket for communicating with the local broker service.
+- `XRD_PELICANMINIMUMHEADERTIMEOUT` (`PelicanMinimumHeaderTimeout`): The minimum
+  time the client can request for a timeout for a response; by default, set to 2s
+  (2 seconds).  Floating point and other suffixes are accepted.
+- `XRD_PELICANDEFAULTHEADERTIMEOUT` (`PelicanDefaultHeaderTimeout`): The default
+  header timeout to use if one is not specified by the client request.  By default,
+  set to 9.5s.
+- `XRD_PELICANFEDERATIONMETADATATIMEOUT` (`PelicanFederationMetadataTimeout`): The
+  timeout for discovering the federation's metadata (including the location of the
+  director service).
+- `XRD_PELICANCACHETOKENLOCATION` (`PelicanCacheTokenLocation`): The location of
+  a token identifying the cache.  If set, the contents of the file will be sent
+  along with any client provided tokens as a separate `Authorization` header.

--- a/src/XrdClPelican/README.md
+++ b/src/XrdClPelican/README.md
@@ -36,3 +36,7 @@ protocol.  The following environment variables control the client configuration
 - `XRD_PELICANCACHETOKENLOCATION` (`PelicanCacheTokenLocation`): The location of
   a token identifying the cache.  If set, the contents of the file will be sent
   along with any client provided tokens as a separate `Authorization` header.
+- `XRD_PELICANDIRECTORYQUERYMODE` (`PelicanDirectoryQueryMode`): Whether to have
+  the client query the director for an origin (set to `origin`), a cache (set to
+  `cache`), or to use the default for the current version of the software (set to
+  `auto`) when requesting to perform an operation on an object.

--- a/tests/XrdClCurlCommon/TransferTest.hh
+++ b/tests/XrdClCurlCommon/TransferTest.hh
@@ -104,6 +104,9 @@ class TransferFixture : public testing::Test {
         // Retrieve a configuration value from the environment file
         const std::string GetEnv(const std::string &) const;
 
+        // Retrieve the currently-used logger object
+        XrdCl::Log *GetLogger() const {return m_log;}
+
     private:
         void ReadTokenFromFile(const std::string &fname, std::string &token);
     

--- a/tests/XrdClPelican/CMakeLists.txt
+++ b/tests/XrdClPelican/CMakeLists.txt
@@ -8,6 +8,7 @@ include( GoogleTest )
 add_executable( xrdcl-pelican-test
   CacheToken.cc
   ChecksumTest.cc
+  DirectorTest.cc
 )
 
 # Unit tests that do not require the pelican fixture

--- a/tests/XrdClPelican/DirectorTest.cc
+++ b/tests/XrdClPelican/DirectorTest.cc
@@ -1,0 +1,65 @@
+/****************************************************************
+ *
+ * Copyright (C) 2025, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+#include "XrdClPelican/PelicanFilesystem.hh"
+#include "../XrdClCurlCommon/TransferTest.hh"
+
+#include <gtest/gtest.h>
+
+class DirectoryTransferFixture : public TransferFixture {
+};
+
+
+TEST_F(DirectoryTransferFixture, QueryModeTest) {
+    auto chunk_ctr = 10;
+
+    auto pelican_url = GetEnv("PELICAN_URL");
+
+    auto url = pelican_url + "/test/query_mode_" + std::to_string(chunk_ctr);
+    ASSERT_NO_FATAL_FAILURE(WritePattern(url, chunk_ctr * 100'000, 'a', chunk_ctr * 10'000));
+
+    // Open the file for reads and ensure we were redirected to the origin
+    XrdCl::File fh;
+    auto read_url = url + "?authz=" + GetReadToken();
+    auto rv = fh.Open(read_url, XrdCl::OpenFlags::Read, XrdCl::Access::Mode(0755), static_cast<Pelican::Filesystem::timeout_t>(10));
+    ASSERT_TRUE(rv.IsOK()) << "Failed to open " << read_url << " for read: " << rv.ToString();
+    std::string location;
+    ASSERT_TRUE(fh.GetProperty("LastURL", location)) << "Failed to get LastURL property";
+    ASSERT_EQ(location, GetOriginURL() + "/test/query_mode_" + std::to_string(chunk_ctr)+ "?authz=" + GetReadToken() + "&xrdclcurl.timeout=9s500ms") << "Expected to be redirected to origin, but LastURL is " << location;
+    rv = fh.Close();
+    ASSERT_TRUE(rv.IsOK());
+
+    // Empty the query cache to ensure we actually re-query
+    XrdCl::FileSystem fs(pelican_url);
+    XrdCl::Buffer buffer;
+    buffer.FromString("pelican.directorcache reset");
+    auto status = fs.Query(XrdCl::QueryCode::Opaque, buffer, nullptr, static_cast<Pelican::Filesystem::timeout_t>(10));
+    ASSERT_TRUE(status.IsOK()) << "Failed to reset director cache: " << status.ToString();
+
+    // Change the query mode to always use cache
+    ASSERT_TRUE(fs.SetProperty("PelicanDirectorQueryMode", "cache"));
+
+    // Open the file for reads and ensure we were redirected to the cache
+    XrdCl::File fh2;
+    rv = fh2.Open(read_url, XrdCl::OpenFlags::Read, XrdCl::Access::Mode(0755), static_cast<Pelican::Filesystem::timeout_t>(10));
+    ASSERT_TRUE(rv.IsOK()) << "Failed to open " << read_url << " for read: " << rv.ToString();
+    ASSERT_TRUE(fh2.GetProperty("LastURL", location)) << "Failed to get LastURL property";
+    ASSERT_EQ(location, GetCacheURL() + "/test/query_mode_" + std::to_string(chunk_ctr)+ "?authz=" + GetReadToken() + "&pelican.timeout=9s500ms&xrdclcurl.timeout=9s500ms") << "Expected to be redirected to cache, but LastURL is " << location;
+    rv = fh2.Close();
+    ASSERT_TRUE(rv.IsOK());
+}

--- a/tests/XrdClPelican/pelican-setup.sh
+++ b/tests/XrdClPelican/pelican-setup.sh
@@ -169,7 +169,7 @@ cat > "$PELICAN_RUNDIR/xrootd-extra.conf" << EOF
 http.exthandler xrdtpc libXrdHttpTPC.so
 
 if named origin
-ofs.osslib ++ $BINARY_DIR/tests/common/libXrdOssSlowOpen.so
+ofs.osslib ++ $BINARY_DIR/tests/XrdClCurlCommon/libXrdOssSlowOpen.so
 fi
 
 pfc.blocksize 8m


### PR DESCRIPTION
If the client is not part of a registered Pelican cache, it won't have the credentials to interact with some origins.

With this PR, there's now a configuration variable allowing the client to request a cache from the director instead.

Fixes #82 