### PR TITLE
Avoid potential deadlock during prefetch constructor (main branch)

### DIFF
--- a/src/XrdClCurl/XrdClCurlFile.cc
+++ b/src/XrdClCurl/XrdClCurlFile.cc
@@ -636,7 +636,11 @@ File::Read(uint64_t                offset,
     }
     auto [status, ok] = ReadPrefetch(offset, size, buffer, handler, timeout, false);
     if (ok) {
-        m_logger->Debug(kLogXrdClCurl, "Read %s (%d bytes at offset %lld) will be served from prefetch handler", m_url.c_str(), size, static_cast<long long>(offset));
+        if (status.IsOK()) {
+            m_logger->Debug(kLogXrdClCurl, "Read %s (%d bytes at offset %lld) will be served from prefetch handler", m_url.c_str(), size, static_cast<long long>(offset));
+        } else {
+            m_logger->Warning(kLogXrdClCurl, "Read %s (%d bytes at offset %lld) failed: %s", m_url.c_str(), size, static_cast<long long>(offset), status.GetErrorMessage().c_str());
+        }
         return status;
     } else if (m_full_download.load(std::memory_order_relaxed)) {
         std::unique_lock lock(m_default_prefetch_handler->m_prefetch_mutex);
@@ -939,7 +943,11 @@ File::PgRead(uint64_t                offset,
     }
     auto [status, ok] = ReadPrefetch(offset, size, buffer, handler, timeout, true);
     if (ok) {
-        m_logger->Debug(kLogXrdClCurl, "PgRead %s (%d bytes at offset %lld) will be served from prefetch handler", m_url.c_str(), size, static_cast<long long>(offset));
+        if (status.IsOK()) {
+            m_logger->Debug(kLogXrdClCurl, "PgRead %s (%d bytes at offset %lld) will be served from prefetch handler", m_url.c_str(), size, static_cast<long long>(offset));
+        } else {
+            m_logger->Warning(kLogXrdClCurl, "PgRead %s (%d bytes at offset %lld) failed: %s", m_url.c_str(), size, static_cast<long long>(offset), status.GetErrorMessage().c_str());
+        }
         return status;
     } else if (m_full_download.load(std::memory_order_relaxed)) {
         return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp, 0, "Non-sequential read detected when in full-download mode");

--- a/src/XrdClCurl/XrdClCurlFile.cc
+++ b/src/XrdClCurl/XrdClCurlFile.cc
@@ -712,7 +712,15 @@ File::ReadPrefetch(uint64_t offset, uint64_t size, void *buffer, XrdCl::Response
             m_logger->Debug(kLogXrdClCurl, "%sRead %s (%llu bytes at offset %lld with timeout %lld; starting prefetch of size %lld)", isPgRead ? "Pg" : "", url.c_str(), static_cast<unsigned long long>(size), static_cast<long long>(offset), static_cast<long long>(ts.tv_sec), static_cast<long long>(m_prefetch_size));
         }
 
-        m_last_prefetch_handler = new PrefetchResponseHandler(*this, offset, size, &m_prefetch_offset, static_cast<char *>(buffer), handler, timeout);
+        try {
+            m_last_prefetch_handler = new PrefetchResponseHandler(*this, offset, size, &m_prefetch_offset, static_cast<char *>(buffer), handler, nullptr, timeout);
+        } catch (std::runtime_error &exc) {
+            m_logger->Warning(kLogXrdClCurl, "Failed to create prefetch response handler: %s", exc.what());
+            m_default_prefetch_handler->m_prefetch_enabled = false;
+            m_prefetch_reads_miss.fetch_add(1, std::memory_order_relaxed);
+            return std::make_tuple(XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errOSError), true);
+        }
+
         // If we are prefetching as part of an open (i.e., a "full download"), there's special handling logic
         // to pass along the response headers as file properties.
         m_prefetch_op.reset(
@@ -763,8 +771,14 @@ File::ReadPrefetch(uint64_t offset, uint64_t size, void *buffer, XrdCl::Response
     if (m_logger->GetLevel() >= XrdCl::Log::LogLevel::DebugMsg) {
         m_logger->Debug(kLogXrdClCurl, "%sRead %s (%llu bytes at offset %lld; using ongoing prefetch)", isPgRead ? "Pg" : "", GetCurrentURL().c_str(), static_cast<unsigned long long>(size), static_cast<long long>(offset));
     }
-    m_last_prefetch_handler = new PrefetchResponseHandler(*this, offset, size, &m_prefetch_offset, static_cast<char *>(buffer), handler, timeout);
-    m_prefetch_reads_hit.fetch_add(1, std::memory_order_relaxed);
+    try {
+        m_last_prefetch_handler = new PrefetchResponseHandler(*this, offset, size, &m_prefetch_offset, static_cast<char *>(buffer), handler, &lock, timeout);
+    } catch (std::runtime_error &exc) {
+        m_logger->Warning(kLogXrdClCurl, "Failed to create prefetch response handler: %s", exc.what());
+        m_default_prefetch_handler->m_prefetch_enabled = false;
+        m_prefetch_reads_miss.fetch_add(1, std::memory_order_relaxed);
+        return std::make_tuple(XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errOSError), true);
+    }
 
     return std::make_tuple(XrdCl::XRootDStatus{}, true);
 }
@@ -1133,7 +1147,7 @@ File::CalculateCurrentURL(const std::string &value) const {
 
 File::PrefetchResponseHandler::PrefetchResponseHandler(
     File &parent, off_t offset, size_t size, std::atomic<off_t> *prefetch_offset, char *buffer,
-    XrdCl::ResponseHandler *handler, timeout_t timeout
+    XrdCl::ResponseHandler *handler, std::unique_lock<std::mutex> *lock, timeout_t timeout
 )
     : m_parent(parent),
     m_handler(handler),
@@ -1147,7 +1161,19 @@ File::PrefetchResponseHandler::PrefetchResponseHandler(
         parent.m_last_prefetch_handler->m_next = this;
     } else {
         m_parent.m_last_prefetch_handler = this;
-        if (m_parent.m_prefetch_op) m_parent.m_prefetch_op->Continue(m_parent.m_prefetch_op, this, buffer, size);
+        // If lock is nullptr, then we are guaranteed that this is called during the creation
+        // of the m_prefetch_op and can skip this check.
+        if (lock && m_parent.m_prefetch_op) {
+            // If continuing the prefetch operation fails, then the failure callback
+            // will be invoked; the callback requires the mutex and hence we need to unlock it
+            // here to avoid a deadlock.
+            lock->unlock();
+            if (!m_parent.m_prefetch_op->Continue(m_parent.m_prefetch_op, this, buffer, size)) {
+                lock->lock();
+                m_parent.m_last_prefetch_handler = nullptr;
+                throw std::runtime_error("Failed to continue prefetch operation");
+            }
+        }
     }
 }
 

--- a/src/XrdClCurl/XrdClCurlFile.hh
+++ b/src/XrdClCurl/XrdClCurlFile.hh
@@ -294,8 +294,29 @@ private:
     // operation to the subsequent entry.
     class PrefetchResponseHandler : public XrdCl::ResponseHandler {
     public:
+
+        // Constructor for the prefetch response handler.
+        // - `parent`: The parent file object for the prefetch.
+        // - `offset`: The offset within the file to start the prefetch.
+        // - `size`: The size of the prefetch operation.
+        // - `prefetch_offset`: A reference to the prefetch offset.  As the prefetch
+        //   operation progresses, this offset will be updated to reflect the new
+        //   position in the file.  Lifetime must exceed that of the response handler.
+        // - `buffer`: A pointer to the buffer to store the prefetch data.
+        // - `handler`: The response handler for the prefetch operation.
+        // - `lock`: A unique lock for the prefetch operation.  If `lock` is the `nullptr`,
+        //   then we assume this is called during the creation of the m_prefetch_op and we
+        //   will assume that this is NOT a continuation of the existing operation.  In that
+        //   case, the lock will not be dropped during the constructor.  A reference to the
+        //   lock is not taken outside the constructor.  The lock must be held when the
+        //   constructor is called.
+        // - `timeout`: The timeout for the prefetch operation.
+        //
+        // The constructor can throw a std::runtime_exception if the handler would have
+        // continued an ongoing prefetch operation but it failed to submit it.
         PrefetchResponseHandler(File &parent,
-            off_t offset, size_t size, std::atomic<off_t> *prefetch_offset, char *buffer, XrdCl::ResponseHandler *handler, timeout_t timeout);
+            off_t offset, size_t size, std::atomic<off_t> *prefetch_offset, char *buffer, XrdCl::ResponseHandler *handler,
+            std::unique_lock<std::mutex> *lock, timeout_t timeout);
 
         virtual void HandleResponse(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response);
 


### PR DESCRIPTION
If the prefetch constructor detects the presence of a prefetch operation, then it will try to continue it immediately.

Unfortunately, if the prefetch operation fails to continue, the failure callback may be invoked, requiring the prefetch mutex. Since the constructor currently holds the mutex, a deadlock occurs.

This fix gives the mutex to the constructor, allowing it to unlock it as necessary around the `Continue` method.

This PR is the version of #93 for the `main` branch.