### PR TITLE
Fix worker slot leak when File::Close() is called with an in-flight prefetch op

### DIFF
--- a/src/XrdClCurl/XrdClCurlFile.cc
+++ b/src/XrdClCurl/XrdClCurlFile.cc
@@ -724,8 +724,18 @@ File::Read(uint64_t                offset,
         }
         return status;
     } else if (m_full_download.load(std::memory_order_relaxed)) {
-        std::unique_lock lock(m_default_prefetch_handler->m_prefetch_mutex);
-        if (m_prefetch_op && m_prefetch_op->IsDone() && (static_cast<off_t>(offset) == m_prefetch_offset.load(std::memory_order_acquire))) {
+        bool eof = false;
+        {
+            std::unique_lock lock(m_default_prefetch_handler->m_prefetch_mutex);
+            eof = m_prefetch_op && m_prefetch_op->IsDone() &&
+                  (static_cast<off_t>(offset) == m_prefetch_offset.load(std::memory_order_acquire));
+        }
+        // Release the lock before calling the user's handler.  The handler may close
+        // the file synchronously (e.g., XrdClS3DownloadHandler reacts to a 0-byte
+        // chunk by calling File::Close), and File::Close → CancelPrefetch re-acquires
+        // the same non-recursive mutex.  Holding the lock across the callback would
+        // deadlock the curl worker thread.
+        if (eof) {
             if (handler) {
                 auto ci = new XrdCl::ChunkInfo(offset, 0, buffer);
                 auto obj = new XrdCl::AnyObject();

--- a/src/XrdClCurl/XrdClCurlFile.cc
+++ b/src/XrdClCurl/XrdClCurlFile.cc
@@ -39,6 +39,7 @@
 using namespace XrdClCurl;
 
 std::atomic<uint64_t> File::m_prefetch_count = 0;
+std::atomic<uint64_t> File::m_prefetch_cancelled_count = 0;
 std::atomic<uint64_t> File::m_prefetch_expired_count = 0;
 std::atomic<uint64_t> File::m_prefetch_failed_count = 0;
 std::atomic<uint64_t> File::m_prefetch_reads_hit = 0;
@@ -336,6 +337,7 @@ File::GetMonitoringJson()
 {
     return "{\"prefetch\": {"
         "\"count\": " + std::to_string(m_prefetch_count) + ","
+        "\"cancelled\": " + std::to_string(m_prefetch_cancelled_count) + ","
         "\"expired\": " + std::to_string(m_prefetch_expired_count) + ","
         "\"failed\": " + std::to_string(m_prefetch_failed_count) + ","
         "\"reads_hit\": " + std::to_string(m_prefetch_reads_hit) + ","
@@ -1311,7 +1313,10 @@ File::PrefetchDefaultHandler::HandleResponse(XrdCl::XRootDStatus *status_raw, Xr
     std::unique_ptr<XrdCl::AnyObject> response(response_raw);
     std::unique_ptr<XrdCl::XRootDStatus> status(status_raw);
     if (status && !status->IsOK()) {
-        if ((status->code == XrdCl::errOperationExpired) && (status->GetErrorMessage().find("Transfer stalled for too long") != std::string::npos)) {
+        if ((status->code == XrdCl::errOperationExpired) && (status->GetErrorMessage().find("Operation cancelled on file close") != std::string::npos)) {
+            m_prefetch_cancelled_count.fetch_add(1, std::memory_order_relaxed);
+            m_logger->Debug(kLogXrdClCurl, "Prefetch op for %s cancelled on file close", m_url.c_str());
+        } else if ((status->code == XrdCl::errOperationExpired) && (status->GetErrorMessage().find("Transfer stalled for too long") != std::string::npos)) {
             m_prefetch_expired_count.fetch_add(1, std::memory_order_relaxed);
             m_logger->Debug(kLogXrdClCurl, "Prefetch data for %s went unused; disabling.", m_url.c_str());
         } else {

--- a/src/XrdClCurl/XrdClCurlFile.cc
+++ b/src/XrdClCurl/XrdClCurlFile.cc
@@ -203,11 +203,15 @@ private:
     XrdCl::ResponseHandler *m_handler;
 };
 
-// Response handler used when Close() is called while a prefetch op is paused in libcurl.
-// Close() calls Continue() with this handler and a 1-byte buffer; libcurl resumes, Write()
-// copies the byte, hits the buffer-full pause point, sees IsCancelled(), and calls this.
-// HandleResponse() routes the cancellation status through PrefetchDefaultHandler so that
-// metrics and prefetch-disable logic run in the same place as other prefetch failures.
+// Response handler installed by File::CancelPrefetch() when a paused prefetch op needs
+// to be woken up just to be torn down.  Holds a strong ref to the PrefetchDefaultHandler
+// (whose lifetime is independent of File) so the cancellation is delivered safely even
+// if File has been destroyed before the worker drains the continue queue.
+//
+// Holds the strong ref via shared_ptr so PrefetchDefaultHandler outlives any in-flight
+// cancellation delivery; otherwise File::~File could destroy the handler before this
+// callback fires.  The 1-byte buffer is unused once Write() short-circuits on
+// IsCancelled(), but a non-null buffer is still required by CurlReadOp::Continue().
 class CancelResponseHandler : public XrdCl::ResponseHandler {
 public:
     explicit CancelResponseHandler(std::shared_ptr<XrdCl::ResponseHandler> dh)
@@ -238,16 +242,49 @@ struct timespec XrdClCurl::File::m_default_header_timeout = {9, 5};
 struct timespec XrdClCurl::File::m_fed_timeout = {5, 0};
 
 
-File::~File() noexcept {
-    // Cancel any outstanding prefetch op so the worker slot is freed promptly.
-    if (m_prefetch_op && !m_prefetch_op->IsDone()) {
-        m_prefetch_op->Cancel();
-        if (m_prefetch_op->IsPaused()) {
-            auto *ch = new CancelResponseHandler(m_default_prefetch_handler);
-            m_prefetch_op->Continue(m_prefetch_op, ch, ch->GetBuffer(), 1);
+void
+File::CancelPrefetch() {
+    // If Open() never succeeded, the prefetch handler is null and there is nothing to do.
+    if (!m_default_prefetch_handler) return;
+    // We must observe and modify m_prefetch_op under m_prefetch_mutex, the same lock
+    // that ReadPrefetch() / PrefetchResponseHandler take, to avoid racing with a
+    // concurrent Read that may be appending to the prefetch handler chain.
+    std::shared_ptr<XrdClCurl::CurlReadOp> op;
+    bool was_paused = false;
+    {
+        std::unique_lock lock(m_default_prefetch_handler->m_prefetch_mutex);
+        if (m_prefetch_op && !m_prefetch_op->IsDone()) {
+            op = m_prefetch_op;
+            // Set the cancel flag while the lock is held: this happens-before any
+            // subsequent worker-thread read of IsCancelled() in CurlReadOp::Write(),
+            // which is the primary deterministic cancellation channel.
+            op->Cancel();
+            // Snapshot IsPaused() under the lock.  Even with m_is_paused atomic, taking
+            // the snapshot here avoids the worker concurrently transitioning the op
+            // through a pause+deliver cycle that would leave it parked indefinitely.
+            was_paused = op->IsPaused();
         }
+        // Once we've decided to cancel, disable further prefetch decisions on this file
+        // so a racing Read() can't observe the cancel-in-progress op and try to extend it.
+        m_default_prefetch_handler->m_prefetch_enabled.store(false, std::memory_order_relaxed);
         m_prefetch_op.reset();
     }
+    if (!op) return;
+    if (was_paused) {
+        // The op is parked in libcurl waiting for the next Read.  Wake the worker via the
+        // continue queue so it can drain the slot promptly.  CurlReadOp::Continue calls
+        // m_continue_queue->Produce, which may briefly block — done outside the lock.
+        // CancelResponseHandler holds a shared_ptr to m_default_prefetch_handler, so the
+        // delivery is safe even if `this` File is destroyed before the worker drains it.
+        auto *ch = new CancelResponseHandler(m_default_prefetch_handler);
+        op->Continue(op, ch, ch->GetBuffer(), 1);
+    }
+    // If not paused, the worker thread will reach CurlReadOp::Write(), observe IsCancelled(),
+    // return 0 from the write callback, and tear the slot down via CURLE_WRITE_ERROR.
+}
+
+File::~File() noexcept {
+    CancelPrefetch();
     auto handler = m_put_handler.load(std::memory_order_acquire);
     if (handler) {
         // We must wait for all ongoing writes to complete; the XrdCl::File
@@ -465,20 +502,9 @@ File::Close(XrdCl::ResponseHandler *handler,
     }
     m_is_opened = false;
 
-    // If there is an outstanding prefetch operation that is paused waiting for the
-    // next Read() call, cancel it now so the worker slot is freed immediately instead
-    // of waiting up to the stall timeout (60s).
-    if (m_prefetch_op && !m_prefetch_op->IsDone()) {
-        m_prefetch_op->Cancel();
-        if (m_prefetch_op->IsPaused()) {
-            // Op is paused in libcurl; create a CancelResponseHandler so that when Write()
-            // resumes, it delivers the cancellation through PrefetchDefaultHandler for
-            // consistent metrics and prefetch-disable logic.
-            auto *ch = new CancelResponseHandler(m_default_prefetch_handler);
-            m_prefetch_op->Continue(m_prefetch_op, ch, ch->GetBuffer(), 1);
-        }
-        m_prefetch_op.reset();
-    }
+    // Tear down any outstanding prefetch op so its worker slot is freed immediately
+    // instead of waiting up to the transfer-stall timeout (60s).
+    CancelPrefetch();
 
     std::unique_ptr<XrdCl::XRootDStatus> status(new XrdCl::XRootDStatus{});
     if (m_put_op && !m_put_op->HasFailed()) {
@@ -1059,6 +1085,16 @@ File::GetProperty(const std::string &name,
         return true;
     }
 
+    // Pseudo-property: returns the plugin-global monitoring JSON.  Useful from
+    // tests, which are linked against a separate copy of libXrdClCurl and cannot
+    // call File::GetMonitoringJson() directly — the plugin and the test SO each
+    // own their own copies of the static atomics under RTLD_LOCAL.  Routing
+    // through GetProperty crosses the plugin boundary correctly.
+    if (name == "XrdClCurlMonitoringJson") {
+        value = GetMonitoringJson();
+        return true;
+    }
+
     std::shared_lock lock(m_properties_mutex);
     if (name == "LastURL") {
         value = m_last_url;
@@ -1313,7 +1349,7 @@ File::PrefetchDefaultHandler::HandleResponse(XrdCl::XRootDStatus *status_raw, Xr
     std::unique_ptr<XrdCl::AnyObject> response(response_raw);
     std::unique_ptr<XrdCl::XRootDStatus> status(status_raw);
     if (status && !status->IsOK()) {
-        if ((status->code == XrdCl::errOperationExpired) && (status->GetErrorMessage().find("Operation cancelled on file close") != std::string::npos)) {
+        if (status->code == XrdCl::errOperationExpired && status->errNo == XrdClCurl::kPrefetchCancelledOnClose) {
             m_prefetch_cancelled_count.fetch_add(1, std::memory_order_relaxed);
             m_logger->Debug(kLogXrdClCurl, "Prefetch op for %s cancelled on file close", m_url.c_str());
         } else if ((status->code == XrdCl::errOperationExpired) && (status->GetErrorMessage().find("Transfer stalled for too long") != std::string::npos)) {

--- a/src/XrdClCurl/XrdClCurlFile.cc
+++ b/src/XrdClCurl/XrdClCurlFile.cc
@@ -285,6 +285,14 @@ File::CancelPrefetch() {
 
 File::~File() noexcept {
     CancelPrefetch();
+    // Detach the prefetch default handler from this File so any in-flight
+    // PrefetchResponseHandler that wakes up after destruction completes sees a
+    // null File pointer (under the lock) and skips touching File-owned memory.
+    // Must happen after CancelPrefetch (which still needs the live File) and
+    // before any other File-owned member is destroyed.
+    if (m_default_prefetch_handler) {
+        m_default_prefetch_handler->DetachFile();
+    }
     auto handler = m_put_handler.load(std::memory_order_acquire);
     if (handler) {
         // We must wait for all ongoing writes to complete; the XrdCl::File
@@ -1235,7 +1243,8 @@ File::PrefetchResponseHandler::PrefetchResponseHandler(
     File &parent, off_t offset, size_t size, std::atomic<off_t> *prefetch_offset, char *buffer,
     XrdCl::ResponseHandler *handler, std::unique_lock<std::mutex> *lock, timeout_t timeout
 )
-    : m_parent(parent),
+    : m_default_handler(parent.m_default_prefetch_handler),
+    m_parent(parent),
     m_handler(handler),
     m_buffer(buffer),
     m_size(size),
@@ -1273,51 +1282,76 @@ File::PrefetchResponseHandler::HandleResponse(XrdCl::XRootDStatus *status, XrdCl
     // Ensure that we are deleted once the callback is done.
     std::unique_ptr<PrefetchResponseHandler> owner(this);
 
+    // All accesses to the parent File MUST go through m_default_handler->GetFileLocked()
+    // while holding m_default_handler->m_prefetch_mutex.  If GetFileLocked() returns
+    // nullptr, the parent File has been destroyed (or is being destroyed) and File-
+    // owned memory (m_prefetch_offset, m_last_prefetch_handler, m_prefetch_op, the
+    // counters static methods on File access by pointer) must not be touched.
+
     bool mismatched_size = false;
-    if (status) {
-        if (status->IsOK() && response) {
-            XrdCl::ChunkInfo *ci = nullptr;
-            response->Get(ci);
-            if (ci) {
-                auto missing_bytes = m_size - ci->GetLength();
-                if (missing_bytes) {
-                    mismatched_size = true;
-                    m_prefetch_offset->fetch_sub(missing_bytes, std::memory_order_relaxed);
+    bool parent_alive = false;
+    PrefetchResponseHandler *next = nullptr;
+    std::shared_ptr<XrdClCurl::CurlReadOp> next_op; // op shared_ptr copied out for the Continue() call below
+
+    {
+        std::unique_lock lock(m_default_handler->m_prefetch_mutex);
+        File *parent = m_default_handler->GetFileLocked();
+        parent_alive = (parent != nullptr);
+
+        if (status) {
+            if (status->IsOK() && response) {
+                XrdCl::ChunkInfo *ci = nullptr;
+                response->Get(ci);
+                if (ci) {
+                    auto missing_bytes = m_size - ci->GetLength();
+                    if (missing_bytes) {
+                        mismatched_size = true;
+                        // m_prefetch_offset points into the parent File; only safe to
+                        // touch while the lock is held and the parent is alive.
+                        if (parent_alive) {
+                            m_prefetch_offset->fetch_sub(missing_bytes, std::memory_order_relaxed);
+                        }
+                    }
+                    m_prefetch_bytes_used.fetch_add(ci->GetLength(), std::memory_order_relaxed);
                 }
-                m_prefetch_bytes_used.fetch_add(ci->GetLength(), std::memory_order_relaxed);
+            } else if (!status->IsOK()) {
+                m_prefetch_failed_count.fetch_add(1, std::memory_order_relaxed);
             }
-        } else if (!status->IsOK()) {
-            m_prefetch_failed_count.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        next = m_next;
+        // Snapshot the prefetch op while the parent is still alive; we will use it
+        // outside the lock to continue the next handler in the chain.
+        if (parent_alive) {
+            next_op = parent->m_prefetch_op;
         }
     }
 
-    PrefetchResponseHandler *next;
-    {
-        std::unique_lock lock(m_parent.m_default_prefetch_handler->m_prefetch_mutex);
-        next = m_next;
-    }
     if (next) {
-        if (status && status->IsOK() && !mismatched_size) {
-            m_parent.m_prefetch_op->Continue(m_parent.m_prefetch_op, next, next->m_buffer, next->m_size);
+        if (parent_alive && next_op && status && status->IsOK() && !mismatched_size) {
+            next_op->Continue(next_op, next, next->m_buffer, next->m_size);
         } else {
             // On failure resubmit subsequent operations.
             // All the subsequent ops also depend on us having the expected read length (otherwise the
             // file offsets are incorrect).  If there's a mismatched read size (shorter actual bytes available
             // than what is originally requested), then that's another sign of potential issue and we disable
             // the prefetch mechanism.
-            m_parent.m_default_prefetch_handler->DisablePrefetch();
-            next->ResubmitOperation();
+            m_default_handler->DisablePrefetch();
+            next->ResubmitOperation(status);
         }
     }
 
     {
-        std::unique_lock lock(m_parent.m_default_prefetch_handler->m_prefetch_mutex);
-        if (m_parent.m_last_prefetch_handler == this) {
-            m_parent.m_last_prefetch_handler = nullptr;
-        }
-        if (!status || !status->IsOK()) {
-            m_parent.m_prefetch_op.reset();
-            m_parent.m_default_prefetch_handler->m_prefetch_enabled = false;
+        std::unique_lock lock(m_default_handler->m_prefetch_mutex);
+        File *parent = m_default_handler->GetFileLocked();
+        if (parent) {
+            if (parent->m_last_prefetch_handler == this) {
+                parent->m_last_prefetch_handler = nullptr;
+            }
+            if (!status || !status->IsOK()) {
+                parent->m_prefetch_op.reset();
+                m_default_handler->m_prefetch_enabled = false;
+            }
         }
     }
 
@@ -1326,18 +1360,46 @@ File::PrefetchResponseHandler::HandleResponse(XrdCl::XRootDStatus *status, XrdCl
 }
 
 void
-File::PrefetchResponseHandler::ResubmitOperation()
+File::PrefetchResponseHandler::ResubmitOperation(XrdCl::XRootDStatus *fallback_status)
 {
-    m_parent.m_logger->Debug(kLogXrdClCurl, "Resubmitting waiting prefetch operations as new reads due to prefetch failure");
+    m_default_handler->m_logger->Debug(kLogXrdClCurl,
+        "Resubmitting waiting prefetch operations as new reads due to prefetch failure");
     PrefetchResponseHandler *next = this;
     while (next) {
         auto cur = next;
-        auto st = next->m_parent.Read(next->m_offset, next->m_size, next->m_buffer, next->m_handler, next->m_timeout);
-        if (!st.IsOK() && next->m_handler) {
-            next->m_handler->HandleResponse(new XrdCl::XRootDStatus(st), nullptr);
+        // Try to resubmit as a direct (non-prefetch) Read.  Only safe to call if the
+        // parent File is still alive — otherwise propagate the failure status directly
+        // to the user's handler.
+        XrdCl::XRootDStatus *delivered_status = nullptr;
+        {
+            std::unique_lock lock(next->m_default_handler->m_prefetch_mutex);
+            File *parent = next->m_default_handler->GetFileLocked();
+            if (parent) {
+                lock.unlock();
+                auto st = parent->Read(next->m_offset, next->m_size, next->m_buffer,
+                                       next->m_handler, next->m_timeout);
+                if (!st.IsOK()) {
+                    delivered_status = new XrdCl::XRootDStatus(st);
+                }
+            } else if (fallback_status) {
+                // Parent gone; deliver the cancellation reason verbatim.
+                delivered_status = new XrdCl::XRootDStatus(*fallback_status);
+            } else {
+                delivered_status = new XrdCl::XRootDStatus(
+                    XrdCl::stError, XrdCl::errOperationExpired,
+                    XrdClCurl::kPrefetchCancelledOnClose,
+                    "File closed before prefetched read completed");
+            }
+        }
+        if (delivered_status) {
+            if (next->m_handler) {
+                next->m_handler->HandleResponse(delivered_status, nullptr);
+            } else {
+                delete delivered_status;
+            }
         }
         {
-            std::unique_lock lock(next->m_parent.m_default_prefetch_handler->m_prefetch_mutex);
+            std::unique_lock lock(next->m_default_handler->m_prefetch_mutex);
             next = next->m_next;
         }
         delete cur;

--- a/src/XrdClCurl/XrdClCurlFile.cc
+++ b/src/XrdClCurl/XrdClCurlFile.cc
@@ -202,6 +202,32 @@ private:
     XrdCl::ResponseHandler *m_handler;
 };
 
+// Response handler used when Close() is called while a prefetch op is paused in libcurl.
+// Close() calls Continue() with this handler and a 1-byte buffer; libcurl resumes, Write()
+// copies the byte, hits the buffer-full pause point, sees IsCancelled(), and calls this.
+// HandleResponse() routes the cancellation status through PrefetchDefaultHandler so that
+// metrics and prefetch-disable logic run in the same place as other prefetch failures.
+class CancelResponseHandler : public XrdCl::ResponseHandler {
+public:
+    explicit CancelResponseHandler(std::shared_ptr<XrdCl::ResponseHandler> dh)
+        : m_dh(std::move(dh)) {}
+
+    char *GetBuffer() { return m_buf; }
+
+    virtual void HandleResponse(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response) override {
+        std::unique_ptr<CancelResponseHandler> self(this);
+        delete response;
+        if (m_dh) {
+            m_dh->HandleResponse(status, nullptr);
+        } else {
+            delete status;
+        }
+    }
+private:
+    std::shared_ptr<XrdCl::ResponseHandler> m_dh;
+    char m_buf[1];
+};
+
 } // anonymous namespace
 
 // Note: these values are typically overwritten by `CurlFactory::CurlFactory`;
@@ -212,6 +238,15 @@ struct timespec XrdClCurl::File::m_fed_timeout = {5, 0};
 
 
 File::~File() noexcept {
+    // Cancel any outstanding prefetch op so the worker slot is freed promptly.
+    if (m_prefetch_op && !m_prefetch_op->IsDone()) {
+        m_prefetch_op->Cancel();
+        if (m_prefetch_op->IsPaused()) {
+            auto *ch = new CancelResponseHandler(m_default_prefetch_handler);
+            m_prefetch_op->Continue(m_prefetch_op, ch, ch->GetBuffer(), 1);
+        }
+        m_prefetch_op.reset();
+    }
     auto handler = m_put_handler.load(std::memory_order_acquire);
     if (handler) {
         // We must wait for all ongoing writes to complete; the XrdCl::File
@@ -427,6 +462,21 @@ File::Close(XrdCl::ResponseHandler *handler,
         return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
     }
     m_is_opened = false;
+
+    // If there is an outstanding prefetch operation that is paused waiting for the
+    // next Read() call, cancel it now so the worker slot is freed immediately instead
+    // of waiting up to the stall timeout (60s).
+    if (m_prefetch_op && !m_prefetch_op->IsDone()) {
+        m_prefetch_op->Cancel();
+        if (m_prefetch_op->IsPaused()) {
+            // Op is paused in libcurl; create a CancelResponseHandler so that when Write()
+            // resumes, it delivers the cancellation through PrefetchDefaultHandler for
+            // consistent metrics and prefetch-disable logic.
+            auto *ch = new CancelResponseHandler(m_default_prefetch_handler);
+            m_prefetch_op->Continue(m_prefetch_op, ch, ch->GetBuffer(), 1);
+        }
+        m_prefetch_op.reset();
+    }
 
     std::unique_ptr<XrdCl::XRootDStatus> status(new XrdCl::XRootDStatus{});
     if (m_put_op && !m_put_op->HasFailed()) {

--- a/src/XrdClCurl/XrdClCurlFile.hh
+++ b/src/XrdClCurl/XrdClCurlFile.hh
@@ -187,6 +187,12 @@ private:
     // Must be called with the m_properties_mutex held for write.
     void CalculateCurrentURL(const std::string &value) const;
 
+    // Cancel any outstanding prefetch operation so the worker slot is freed
+    // promptly instead of waiting up to the transfer-stall timeout.  Called from
+    // Close() and the destructor.  Acquires m_default_prefetch_handler->m_prefetch_mutex
+    // internally; callers must not hold it.
+    void CancelPrefetch();
+
     bool m_is_opened{false};
     std::atomic<bool> m_full_download{false}; // Whether the file was in "full download mode" when opened.
 

--- a/src/XrdClCurl/XrdClCurlFile.hh
+++ b/src/XrdClCurl/XrdClCurlFile.hh
@@ -293,6 +293,10 @@ private:
     // Protected by m_prefetch_mutex
     std::atomic<off_t> m_prefetch_offset{0};
 
+    // Forward declaration: PrefetchResponseHandler holds a shared_ptr to this so
+    // it can synchronise against File destruction via DetachFile().
+    class PrefetchDefaultHandler;
+
     // Prefetch callback handler class
     //
     // Objects form a linked list of pending prefetch handlers.
@@ -328,9 +332,21 @@ private:
 
     private:
         // When the prefetch fails, we must resubmit our handler as a non-prefetching read.
-        void ResubmitOperation();
+        // Resubmits via parent->Read if the parent File is still alive (m_default_handler->
+        // GetFileLocked() != nullptr); otherwise propagates the cancellation to each
+        // chained handler with the given status.
+        void ResubmitOperation(XrdCl::XRootDStatus *fallback_status);
 
-        // The open file we are associated with
+        // Strong reference to the default prefetch handler.  Keeps the handler's
+        // mutex and File*-tracking state alive even after the parent File has been
+        // destroyed, so a worker-thread callback firing after ~File can safely
+        // synchronise and skip accesses to dead File memory.
+        std::shared_ptr<PrefetchDefaultHandler> m_default_handler;
+
+        // The open file we are associated with.  Raw reference because it is set at
+        // construction time on the live File, but no member function may dereference
+        // this except via m_default_handler->GetFileLocked() under the lock — that
+        // is the only thread-safe way to know File is still alive.
         File &m_parent;
 
         // A reference to the handler we are wrapping.  Note we don't own the handler
@@ -375,7 +391,8 @@ private:
     // prefetching.
     class PrefetchDefaultHandler : public XrdCl::ResponseHandler {
     public:
-        PrefetchDefaultHandler(File &file) : m_logger(file.m_logger), m_url(file.m_url) {}
+        PrefetchDefaultHandler(File &file)
+            : m_logger(file.m_logger), m_url(file.m_url), m_file(&file) {}
 
         virtual void HandleResponse(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response);
 
@@ -398,6 +415,21 @@ private:
             return false;
         }
 
+        // Detach the parent File pointer.  Called by File::~File just before File-
+        // owned data is freed, so that any in-flight PrefetchResponseHandler that
+        // wakes up afterwards sees a null File pointer and skips File accesses.
+        // Must be called while no other thread is mid-callback against m_file —
+        // the m_prefetch_mutex serializes that.
+        void DetachFile() {
+            std::unique_lock lock(m_prefetch_mutex);
+            m_file = nullptr;
+        }
+
+        // Read the parent File pointer.  Caller MUST be holding m_prefetch_mutex;
+        // any File-owned memory derived from this pointer is only safe to access
+        // while the lock is held.
+        File *GetFileLocked() const { return m_file; }
+
         XrdCl::Log *m_logger{nullptr};
         std::string m_url;
 
@@ -412,6 +444,12 @@ private:
         // m_prefetch_mutex held to ensure is actually true and not
         // a spurious reading.
         mutable std::atomic<bool> m_prefetch_enabled{true};
+
+    private:
+        // Pointer to the parent File.  Initialised in the constructor and cleared
+        // by DetachFile() under m_prefetch_mutex when the File is being destroyed.
+        // Only safe to dereference while holding m_prefetch_mutex.
+        File *m_file{nullptr};
     };
 
     // "Default" handler for prefetching

--- a/src/XrdClCurl/XrdClCurlFile.hh
+++ b/src/XrdClCurl/XrdClCurlFile.hh
@@ -436,6 +436,7 @@ private:
     HeaderCallout m_default_header_callout{*this};
 
     static std::atomic<uint64_t> m_prefetch_count; // Count of prefetch operations that have been initiated.
+    static std::atomic<uint64_t> m_prefetch_cancelled_count; // Count of prefetch operations cancelled on file close.
     static std::atomic<uint64_t> m_prefetch_expired_count; // Count of prefetch operations that have expired due to unused data.
     static std::atomic<uint64_t> m_prefetch_failed_count; // Count of prefetch operations that have failed due to errors.
     static std::atomic<uint64_t> m_prefetch_reads_hit; // Count of read operations served from prefetch data.

--- a/src/XrdClCurl/XrdClCurlOpRead.cc
+++ b/src/XrdClCurl/XrdClCurlOpRead.cc
@@ -249,6 +249,15 @@ size_t
 CurlReadOp::Write(char *buffer, size_t length)
 {
     //m_logger->Debug(kLogXrdClCurl, "Received a write of size %ld with offset %lld; total received is %ld; remaining is %ld", static_cast<long>(length), static_cast<long long>(m_op.first), static_cast<long>(length + m_written), static_cast<long>(m_op.second - length - m_written));
+    // If the file was closed mid-transfer, abort the transfer from here instead of buffering
+    // more data.  Returning 0 yields CURLE_WRITE_ERROR, which the worker thread's
+    // CURLE_ABORTED_BY_CALLBACK/CURLE_WRITE_ERROR branch routes through the IsCancelled()
+    // cleanup path.  This closes the TOCTOU window in File::Close() between Cancel() and
+    // IsPaused(): even if Close() observed the op as not-yet-paused, the next Write()
+    // callback aborts cleanly.
+    if (IsCancelled()) {
+        return 0;
+    }
     if (m_headers.IsMultipartByterange()) {
         return FailCallback(kXR_ServerError, "Server responded with a multipart byterange which is not supported");
     }

--- a/src/XrdClCurl/XrdClCurlOps.cc
+++ b/src/XrdClCurl/XrdClCurlOps.cc
@@ -386,8 +386,11 @@ NullCallback(char * /*buffer*/, size_t size, size_t nitems, void * /*this_ptr*/)
 
 void
 CurlOperation::SetPaused(bool paused) {
-    m_is_paused = paused;
-    if (m_is_paused) {
+    // Release-store so that observers of m_is_paused = true (e.g., File::Close on
+    // another thread) see a happens-before relationship with any prior worker-thread
+    // writes (m_handler = nullptr after DeliverResponse, etc.).
+    m_is_paused.store(paused, std::memory_order_release);
+    if (paused) {
         m_pause_start = std::chrono::steady_clock::now();
     } else if (m_pause_start != std::chrono::steady_clock::time_point{}) {
         m_pause_duration += std::chrono::steady_clock::now() - m_pause_start;

--- a/src/XrdClCurl/XrdClCurlOps.hh
+++ b/src/XrdClCurl/XrdClCurlOps.hh
@@ -54,6 +54,13 @@ class CurlWorker;
 class File;
 class ResponseInfo;
 
+// Sentinel errNum attached to the XRootDStatus delivered when a prefetch op is
+// cancelled by File::Close() / File::~File().  Routed through PrefetchDefaultHandler
+// so it can be classified into m_prefetch_cancelled_count without string-matching
+// the error message.  Picked to be distinct from any plausible value of `errno`,
+// `XErrorCode` (kXR_*), or libcurl's CURLcode.
+constexpr uint32_t kPrefetchCancelledOnClose = 0x4F434C53; // "OCLS"
+
 class CurlOperation {
 public:
     using HeaderList = std::vector<std::pair<std::string, std::string>>;
@@ -235,8 +242,9 @@ public:
     // Return true if the transfer is done
     bool IsDone() const {return m_done;}
 
-    // Return true if the operation is paused in libcurl
-    bool IsPaused() const {return m_is_paused;}
+    // Return true if the operation is paused in libcurl.
+    // Safe to call from any thread.
+    bool IsPaused() const {return m_is_paused.load(std::memory_order_acquire);}
 
     // Returns true if the operation has been marked as failed.
     bool HasFailed() const {return m_has_failed.load(std::memory_order_acquire);}
@@ -343,7 +351,9 @@ private:
     bool m_done{false};
     std::atomic<bool> m_has_failed{false};
     std::atomic<bool> m_cancelled{false};
-    bool m_is_paused{false};
+    // Whether libcurl has paused the transfer.  Set by the worker thread inside SetPaused()
+    // and read by the app thread in File::Close()/~File() — hence atomic.
+    std::atomic<bool> m_is_paused{false};
     int m_conn_callout_result{-1}; // The result of the connection callout
     int m_conn_callout_listener{-1}; // The listener socket for the connection callout
     uint64_t m_bytes{0}; // Count of bytes transferred by operation since last StatisticsReset()

--- a/src/XrdClCurl/XrdClCurlOps.hh
+++ b/src/XrdClCurl/XrdClCurlOps.hh
@@ -241,6 +241,12 @@ public:
     // Returns true if the operation has been marked as failed.
     bool HasFailed() const {return m_has_failed.load(std::memory_order_acquire);}
 
+    // Marks the operation as cancelled; the next Write() callback will abort cleanly.
+    void Cancel() {m_cancelled.store(true, std::memory_order_release);}
+
+    // Returns true if the operation has been cancelled.
+    bool IsCancelled() const {return m_cancelled.load(std::memory_order_acquire);}
+
     // Resets the statistics for the operation and returns a tuple of:
     // - bytes transferred,
     // - duration between operation start and header receipt.
@@ -336,6 +342,7 @@ private:
     bool m_received_header{false};
     bool m_done{false};
     std::atomic<bool> m_has_failed{false};
+    std::atomic<bool> m_cancelled{false};
     bool m_is_paused{false};
     int m_conn_callout_result{-1}; // The result of the connection callout
     int m_conn_callout_listener{-1}; // The listener socket for the connection callout

--- a/src/XrdClCurl/XrdClCurlUtil.cc
+++ b/src/XrdClCurl/XrdClCurlUtil.cc
@@ -62,6 +62,7 @@ std::atomic<uint64_t> CurlWorker::m_conncall_errors = 0;
 std::atomic<uint64_t> CurlWorker::m_conncall_req = 0;
 std::atomic<uint64_t> CurlWorker::m_conncall_success = 0;
 std::atomic<uint64_t> CurlWorker::m_conncall_timeout = 0;
+std::atomic<uint64_t> CurlWorker::m_cancelled_ops = 0;
 decltype(CurlWorker::m_ops) CurlWorker::m_ops = {};
 std::vector<std::atomic<std::chrono::system_clock::rep>*> CurlWorker::m_workers_last_completed_cycle;
 std::vector<std::atomic<std::chrono::system_clock::rep>*> CurlWorker::m_workers_oldest_op;
@@ -992,7 +993,8 @@ CurlWorker::GetMonitoringJson()
         "\"conncall_error\":" + std::to_string(m_conncall_errors.load(std::memory_order_relaxed)) + ","
         "\"conncall_started\":" + std::to_string(m_conncall_req.load(std::memory_order_relaxed)) + ","
         "\"conncall_success\":" + std::to_string(m_conncall_success.load(std::memory_order_relaxed)) + ","
-        "\"conncall_timeout\":" + std::to_string(m_conncall_timeout.load(std::memory_order_relaxed)) +
+        "\"conncall_timeout\":" + std::to_string(m_conncall_timeout.load(std::memory_order_relaxed)) + ","
+        "\"cancelled_ops\":" + std::to_string(m_cancelled_ops.load(std::memory_order_relaxed)) +
         "}";
 
     return retval;
@@ -1130,6 +1132,7 @@ CurlWorker::Run() {
                     m_op_map.erase(curl);
                 }
                 running_handles -= 1;
+                m_cancelled_ops.fetch_add(1, std::memory_order_relaxed);
                 continue;
             }
             m_logger->Debug(kLogXrdClCurl, "Continuing the curl handle from op %p on thread %d", op.get(), getthreadid());

--- a/src/XrdClCurl/XrdClCurlUtil.cc
+++ b/src/XrdClCurl/XrdClCurlUtil.cc
@@ -1116,6 +1116,22 @@ CurlWorker::Run() {
                 m_logger->Debug(kLogXrdClCurl, "Ignoring continuation of operation that has already completed");
                 continue;
             }
+            // If the file was closed while this op was paused, deliver the cancellation
+            // and remove the paused handle from the multi handle directly — no need to
+            // unpause libcurl and drive through the write callback.
+            if (op->IsCancelled()) {
+                m_logger->Debug(kLogXrdClCurl, "Cancelling paused op for %s on file close", ObjectForLog(op->GetUrl()).c_str());
+                auto curl = op->GetCurlHandle();
+                op->Fail(XrdCl::errOperationExpired, 0, "Operation cancelled on file close");
+                op->ReleaseHandle();
+                if (curl) {
+                    curl_multi_remove_handle(multi_handle, curl);
+                    curl_easy_cleanup(curl);
+                    m_op_map.erase(curl);
+                }
+                running_handles -= 1;
+                continue;
+            }
             m_logger->Debug(kLogXrdClCurl, "Continuing the curl handle from op %p on thread %d", op.get(), getthreadid());
             auto curl = op->GetCurlHandle();
             if (!op->ContinueHandle()) {
@@ -1590,7 +1606,12 @@ CurlWorker::Run() {
                     if (res == CURLE_ABORTED_BY_CALLBACK || res == CURLE_WRITE_ERROR) {
                         // We cannot invoke the failure from within a callback as the curl thread and
                         // original thread of execution may fight over the ownership of the handle memory.
-                        switch (op->GetError()) {
+                        if (op->IsCancelled()) {
+                            // The file was closed while this prefetch op was paused.  Write() already
+                            // delivered a cancellation status to any waiting handler; just clean up.
+                            m_logger->Debug(kLogXrdClCurl, "Prefetch op for %s was cancelled on file close; cleaning up slot",
+                                ObjectForLog(op->GetUrl()).c_str());
+                        } else switch (op->GetError()) {
                         case CurlOperation::OpError::ErrHeaderTimeout:
                             m_logger->Debug(kLogXrdClCurl, "Assigning ErrHeaderTimeout to %s", ObjectForLog(op->GetUrl()).c_str());
 #ifdef HAVE_XPROTOCOL_TIMEREXPIRED
@@ -1628,6 +1649,10 @@ CurlWorker::Run() {
                             break;
                         case CurlOperation::OpError::ErrNone:
                             op->Fail(XrdCl::errInternal, 0, "Operation was aborted without recording an abort reason");
+                            OpRecord(*op, OpKind::Error);
+                            break;
+                        default:
+                            op->Fail(XrdCl::errInternal, 0, "Operation was aborted with an unrecognised abort reason");
                             OpRecord(*op, OpKind::Error);
                             break;
                         };

--- a/src/XrdClCurl/XrdClCurlUtil.cc
+++ b/src/XrdClCurl/XrdClCurlUtil.cc
@@ -1121,18 +1121,28 @@ CurlWorker::Run() {
             // If the file was closed while this op was paused, deliver the cancellation
             // and remove the paused handle from the multi handle directly — no need to
             // unpause libcurl and drive through the write callback.
+            //
+            // Ordering matters: detach the easy handle from the multi handle *and* clear
+            // the write callbacks before invoking op->Fail(), because Fail() runs the
+            // (CancelResponseHandler-)attached handler which may delete the 1-byte buffer
+            // that op->m_buffer still references.  Once curl_multi_remove_handle and
+            // ReleaseHandle have run, libcurl can no longer dispatch a Write() against
+            // that buffer.
             if (op->IsCancelled()) {
                 m_logger->Debug(kLogXrdClCurl, "Cancelling paused op for %s on file close", ObjectForLog(op->GetUrl()).c_str());
                 auto curl = op->GetCurlHandle();
-                op->Fail(XrdCl::errOperationExpired, 0, "Operation cancelled on file close");
-                op->ReleaseHandle();
                 if (curl) {
                     curl_multi_remove_handle(multi_handle, curl);
+                }
+                op->ReleaseHandle();
+                if (curl) {
                     curl_easy_cleanup(curl);
                     m_op_map.erase(curl);
                 }
                 running_handles -= 1;
                 m_cancelled_ops.fetch_add(1, std::memory_order_relaxed);
+                op->Fail(XrdCl::errOperationExpired, XrdClCurl::kPrefetchCancelledOnClose,
+                    "Operation cancelled on file close");
                 continue;
             }
             m_logger->Debug(kLogXrdClCurl, "Continuing the curl handle from op %p on thread %d", op.get(), getthreadid());
@@ -1610,10 +1620,19 @@ CurlWorker::Run() {
                         // We cannot invoke the failure from within a callback as the curl thread and
                         // original thread of execution may fight over the ownership of the handle memory.
                         if (op->IsCancelled()) {
-                            // The file was closed while this prefetch op was paused.  Write() already
-                            // delivered a cancellation status to any waiting handler; just clean up.
+                            // The file was closed while this prefetch op was *running* (not paused —
+                            // the paused path is handled by the continue-queue branch in this worker
+                            // before curl_multi_perform).  Write() aborted the transfer by returning 0;
+                            // we still owe a response to whatever handler the op was carrying, otherwise
+                            // a chained PrefetchResponseHandler (and any pending user Reads it heads)
+                            // would leak.  CurlReadOp::Fail dispatches to m_handler if non-null and falls
+                            // back to m_default_handler (PrefetchDefaultHandler) otherwise; both routes
+                            // classify the status via the kPrefetchCancelledOnClose sentinel.
                             m_logger->Debug(kLogXrdClCurl, "Prefetch op for %s was cancelled on file close; cleaning up slot",
                                 ObjectForLog(op->GetUrl()).c_str());
+                            op->Fail(XrdCl::errOperationExpired, XrdClCurl::kPrefetchCancelledOnClose,
+                                "Operation cancelled on file close");
+                            m_cancelled_ops.fetch_add(1, std::memory_order_relaxed);
                         } else switch (op->GetError()) {
                         case CurlOperation::OpError::ErrHeaderTimeout:
                             m_logger->Debug(kLogXrdClCurl, "Assigning ErrHeaderTimeout to %s", ObjectForLog(op->GetUrl()).c_str());

--- a/src/XrdClCurl/XrdClCurlWorker.hh
+++ b/src/XrdClCurl/XrdClCurlWorker.hh
@@ -134,7 +134,7 @@ private:
     static std::atomic<uint64_t> m_conncall_req;
     static std::atomic<uint64_t> m_conncall_success;
     static std::atomic<uint64_t> m_conncall_timeout;
-    static std::atomic<uint64_t> m_cancelled_ops; 
+    static std::atomic<uint64_t> m_cancelled_ops;
     static std::array<std::array<OpStats, 403>, static_cast<size_t>(XrdClCurl::CurlOperation::HttpVerb::Count)> m_ops;
     std::atomic<std::chrono::system_clock::rep> m_last_completed_cycle;
     std::atomic<std::chrono::system_clock::rep> m_oldest_op;

--- a/src/XrdClCurl/XrdClCurlWorker.hh
+++ b/src/XrdClCurl/XrdClCurlWorker.hh
@@ -134,6 +134,7 @@ private:
     static std::atomic<uint64_t> m_conncall_req;
     static std::atomic<uint64_t> m_conncall_success;
     static std::atomic<uint64_t> m_conncall_timeout;
+    static std::atomic<uint64_t> m_cancelled_ops; 
     static std::array<std::array<OpStats, 403>, static_cast<size_t>(XrdClCurl::CurlOperation::HttpVerb::Count)> m_ops;
     std::atomic<std::chrono::system_clock::rep> m_last_completed_cycle;
     std::atomic<std::chrono::system_clock::rep> m_oldest_op;

--- a/tests/XrdClCurl/CMakeLists.txt
+++ b/tests/XrdClCurl/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable( xrdcl-connection-test
 
 # Tests depending on XrdClCurl linkage
 add_executable( xrdcl-curl-test
+  CloseDuringPrefetchTest.cc
   CopyTest.cc
   ParseTimeoutTest.cc
   VectorReadTest.cc
@@ -33,7 +34,7 @@ add_executable( xrdcl-curl-test
 
 target_link_libraries( xrdcl-test XrdClCurlTransferTest nlohmann_json::nlohmann_json GTest::gtest_main )
 target_link_libraries( xrdcl-connection-test XrdClCurlTransferTest nlohmann_json::nlohmann_json GTest::gtest_main )
-target_link_libraries( xrdcl-curl-test XrdClCurlTesting XrdClCurlTransferTest GTest::gtest_main )
+target_link_libraries( xrdcl-curl-test XrdClCurlTesting XrdClCurlTransferTest nlohmann_json::nlohmann_json GTest::gtest_main )
 
 gtest_add_tests( TARGET xrdcl-test TEST_LIST CurlClOnlyTests )
 set_tests_properties( ${CurlClOnlyTests}

--- a/tests/XrdClCurl/CloseDuringPrefetchTest.cc
+++ b/tests/XrdClCurl/CloseDuringPrefetchTest.cc
@@ -187,3 +187,92 @@ TEST_F(CloseDuringPrefetchFixture, RapidCloseCancelsPrefetch)
         << "Rapid open/read/close took " << elapsed_ms
         << " ms; expected <30s.";
 }
+
+namespace {
+
+// Async response handler used by the Race 5 stress test.  Stores its status
+// for later inspection and signals a condition variable when complete.
+class AsyncResponseHandler : public XrdCl::ResponseHandler {
+public:
+    void HandleResponse(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response) override {
+        delete response;
+        std::unique_lock lock(m_mutex);
+        m_status.reset(status);
+        m_done = true;
+        m_cv.notify_all();
+    }
+
+    void Wait(std::chrono::milliseconds timeout) {
+        std::unique_lock lock(m_mutex);
+        m_cv.wait_for(lock, timeout, [&]{ return m_done; });
+    }
+
+    bool Done() const {
+        std::unique_lock lock(m_mutex);
+        return m_done;
+    }
+
+private:
+    mutable std::mutex m_mutex;
+    std::condition_variable m_cv;
+    bool m_done{false};
+    std::unique_ptr<XrdCl::XRootDStatus> m_status;
+};
+
+} // namespace
+
+// Exercise Race 5: a PrefetchResponseHandler whose worker-thread callback fires
+// AFTER File::~File has run.  Without the fix, the handler's `File &m_parent`
+// is dangling and the dereference inside HandleResponse / ResubmitOperation is
+// UAF.  With the fix, PrefetchResponseHandler holds a shared_ptr to the
+// lifetime-safe PrefetchDefaultHandler and gates all File accesses on an
+// atomic-snapshot-under-lock of m_file (cleared by File::~File via DetachFile).
+//
+// Strategy: do a couple of sync Reads first so the prefetch op enters its
+// paused-with-no-pending-handler state, THEN drop the File.  In that state
+// CancelPrefetch posts a CancelResponseHandler via the continue queue, so the
+// PrefetchResponseHandler chain (which is empty by now) is not the failure
+// point — instead, what we're stressing is the destructor ordering: ~File runs
+// DetachFile, member dtors run, the worker dispatches the cancellation, and
+// any callback that races into PrefetchResponseHandler::HandleResponse must
+// see m_file=nullptr and skip File memory cleanly.
+TEST_F(CloseDuringPrefetchFixture, ParentDetachIsSafe)
+{
+    constexpr size_t chunk_size = 64 * 1024;
+    constexpr off_t file_size = 16 * 1024 * 1024;
+    constexpr unsigned char starting_char = 'b';
+    constexpr int kIterations = 30;
+
+    auto url_base = GetOriginURL() + "/test/close_during_prefetch_detach";
+    ASSERT_NO_FATAL_FAILURE(WritePattern(url_base, file_size, starting_char, chunk_size));
+    auto url = url_base + "?authz=" + GetReadToken();
+
+    for (int i = 0; i < kIterations; ++i) {
+        auto fh = std::make_unique<XrdCl::File>();
+        auto rv = fh->Open(url, XrdCl::OpenFlags::Read, XrdCl::Access::Mode(0755),
+                           static_cast<XrdClCurl::File::timeout_t>(10));
+        ASSERT_TRUE(rv.IsOK()) << "iter " << i << " open failed: " << rv.ToString();
+
+        // Two sync Reads put the prefetch op into the paused state with no
+        // pending handler.  This is the dominant cancel scenario in the field.
+        std::string buf1(chunk_size, '\0');
+        std::string buf2(chunk_size, '\0');
+        uint32_t got = 0;
+        rv = fh->Read(0, chunk_size, buf1.data(), got);
+        ASSERT_TRUE(rv.IsOK()) << "iter " << i << " read#1 failed";
+        rv = fh->Read(chunk_size, chunk_size, buf2.data(), got);
+        ASSERT_TRUE(rv.IsOK()) << "iter " << i << " read#2 failed";
+
+        // Drop File while the prefetch op is still paused in the worker.
+        // ~File runs CancelPrefetch (cancels + queues wakeup) then DetachFile
+        // (atomically clears the File* on PrefetchDefaultHandler), then
+        // members destruct.  Any callback racing in afterwards must see
+        // m_file=nullptr under the lock and skip File-owned memory.
+        fh.reset();
+    }
+
+    // If a callback dereferenced freed File memory we'd typically see a crash
+    // (ASan SEGV / pure-virtual) before reaching here; passing this loop
+    // is the regression check.
+    SUCCEED() << kIterations << " parent-detach iterations completed without UAF";
+}

--- a/tests/XrdClCurl/CloseDuringPrefetchTest.cc
+++ b/tests/XrdClCurl/CloseDuringPrefetchTest.cc
@@ -1,0 +1,189 @@
+/****************************************************************
+ *
+ * Copyright (C) 2026, Pelican Project, Morgridge Institute for Research
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ***************************************************************/
+
+// Regression test for the bug where prefetch operations lingered in a paused
+// libcurl state after File::Close(), accumulating worker slots until they
+// expired via the transfer-stall timeout (default 60s).  Under repeated
+// open/read/close traffic this exhausted the worker thread's max-ops budget
+// and made the file system unresponsive — subsequent Open() calls would block
+// in HandlerQueue::Produce on the producer CV until a slot freed up.
+
+#include "XrdClCurl/XrdClCurlFile.hh"
+#include "../XrdClCurlCommon/TransferTest.hh"
+
+#include <XrdCl/XrdClDefaultEnv.hh>
+#include <XrdCl/XrdClFile.hh>
+#include <XrdCl/XrdClLog.hh>
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <string>
+
+class CloseDuringPrefetchFixture : public TransferFixture {};
+
+namespace {
+
+struct PrefetchCounters {
+    uint64_t count{0};
+    uint64_t cancelled{0};
+    uint64_t expired{0};
+    uint64_t failed{0};
+};
+
+// Read the plugin's per-process prefetch counters via the
+// "XrdClCurlMonitoringJson" pseudo-property exposed by File::GetProperty.  We
+// route through the property bag (rather than calling File::GetMonitoringJson
+// directly) because XrdCl loads libXrdClCurl-5.so as a private plugin
+// (RTLD_LOCAL) and the test binary links a separate copy of the library —
+// only the property path crosses the plugin boundary into the right counters.
+PrefetchCounters ReadPrefetchCounters(XrdCl::File &fh) {
+    std::string js_str;
+    EXPECT_TRUE(fh.GetProperty("XrdClCurlMonitoringJson", js_str));
+    auto js = nlohmann::json::parse(js_str);
+    const auto &pf = js.at("prefetch");
+    PrefetchCounters c;
+    c.count = pf.at("count").get<uint64_t>();
+    c.cancelled = pf.at("cancelled").get<uint64_t>();
+    c.expired = pf.at("expired").get<uint64_t>();
+    c.failed = pf.at("failed").get<uint64_t>();
+    return c;
+}
+
+} // namespace
+
+// Open a file, read enough chunks to trigger prefetch, then Close() before
+// the prefetch has finished.  Repeat many times.
+//
+// We use a body well over a megabyte so the prefetch op cannot complete in
+// the gap between the second Read() returning and Close() running, even on
+// loopback — this guarantees the op is still in libcurl (running or paused)
+// at the moment Close fires.
+TEST_F(CloseDuringPrefetchFixture, RapidCloseCancelsPrefetch)
+{
+    constexpr size_t chunk_size = 64 * 1024;       // 64 KB per Read
+    constexpr off_t file_size = 64 * 1024 * 1024;  // 64 MB body
+
+    // The worker's per-thread budget is 20 in-flight ops (XrdClCurlWorker.hh
+    // m_max_ops); we deliberately exceed it so that the bug — paused ops
+    // pinning slots until the 60s stall timeout — would surface as a hang.
+    constexpr int kIterations = 40;
+    constexpr unsigned char starting_char = 'a';
+
+    auto url_base = GetOriginURL() + "/test/close_during_prefetch";
+    ASSERT_NO_FATAL_FAILURE(WritePattern(url_base, file_size, starting_char, chunk_size));
+
+    auto url = url_base + "?authz=" + GetReadToken();
+
+    // Read the baseline once via a throwaway file — this also forces the
+    // plugin to load now so the counters are zero-relative to this point.
+    PrefetchCounters before;
+    {
+        XrdCl::File fh;
+        auto rv = fh.Open(url, XrdCl::OpenFlags::Read, XrdCl::Access::Mode(0755),
+                          static_cast<XrdClCurl::File::timeout_t>(10));
+        ASSERT_TRUE(rv.IsOK()) << "baseline Open failed: " << rv.ToString();
+        before = ReadPrefetchCounters(fh);
+        ASSERT_TRUE(fh.Close().IsOK());
+    }
+
+    auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < kIterations; ++i) {
+        XrdCl::File fh;
+        auto rv = fh.Open(url, XrdCl::OpenFlags::Read, XrdCl::Access::Mode(0755),
+                          static_cast<XrdClCurl::File::timeout_t>(10));
+        ASSERT_TRUE(rv.IsOK()) << "Iteration " << i << " Open failed: " << rv.ToString();
+
+        // Two synchronous reads engage the prefetch mechanism (the second
+        // read appends a new handler to the in-flight op).  After the
+        // second read returns, the prefetch op is left running in the
+        // background with hundreds of times the just-consumed bytes still
+        // to transfer.
+        std::string buf1(chunk_size, '\0');
+        std::string buf2(chunk_size, '\0');
+        uint32_t got = 0;
+        rv = fh.Read(0, chunk_size, buf1.data(), got);
+        ASSERT_TRUE(rv.IsOK()) << "Iteration " << i << " Read#1 failed";
+        rv = fh.Read(chunk_size, chunk_size, buf2.data(), got);
+        ASSERT_TRUE(rv.IsOK()) << "Iteration " << i << " Read#2 failed";
+
+        // Close immediately while the prefetch op is still outstanding.
+        // This is the line that, pre-fix, would silently leave a paused op
+        // pinned to a worker slot for up to 60s.
+        rv = fh.Close();
+        ASSERT_TRUE(rv.IsOK()) << "Iteration " << i << " Close failed: " << rv.ToString();
+    }
+    auto elapsed = std::chrono::steady_clock::now() - t0;
+    auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
+
+    // Re-read the counters via a fresh open; we cannot reuse the loop's
+    // `fh` because it's been closed.
+    PrefetchCounters after;
+    {
+        XrdCl::File fh;
+        auto rv = fh.Open(url, XrdCl::OpenFlags::Read, XrdCl::Access::Mode(0755),
+                          static_cast<XrdClCurl::File::timeout_t>(10));
+        ASSERT_TRUE(rv.IsOK());
+        after = ReadPrefetchCounters(fh);
+        ASSERT_TRUE(fh.Close().IsOK());
+    }
+    auto count_delta = after.count - before.count;
+    auto cancelled_delta = after.cancelled - before.cancelled;
+    auto expired_delta = after.expired - before.expired;
+    auto failed_delta = after.failed - before.failed;
+    std::cerr << "Prefetch counters delta: count=" << count_delta
+              << " cancelled=" << cancelled_delta
+              << " expired=" << expired_delta
+              << " failed=" << failed_delta
+              << " elapsed_ms=" << elapsed_ms
+              << std::endl;
+
+    // Confirm prefetch fired in roughly every iteration.  If it didn't, the
+    // body of the test isn't exercising the cancel path — perhaps the file
+    // size threshold changed or the read pattern stopped triggering prefetch.
+    EXPECT_GE(count_delta, static_cast<uint64_t>(kIterations) / 2)
+        << "Expected at least " << (kIterations / 2)
+        << " prefetch ops to start; saw " << count_delta;
+
+    // The prefetch-cancel counter should have advanced by roughly the
+    // iteration count.  Not every iteration is guaranteed to leave the op
+    // outstanding (a very fast origin can finish before Close runs), so we
+    // require a majority rather than all.
+    EXPECT_GE(cancelled_delta, static_cast<uint64_t>(kIterations) / 2)
+        << "Expected at least " << (kIterations / 2)
+        << " prefetch cancellations; saw " << cancelled_delta;
+
+    // The stall-expiry path is the *old* behavior we replaced.  If it
+    // fires, it means Close failed to deliver the cancellation and the op
+    // sat until libcurl's 60s transfer-stall timer expired.
+    EXPECT_LT(expired_delta, cancelled_delta)
+        << "Stall-expiry count (" << expired_delta
+        << ") exceeded cancellation count (" << cancelled_delta
+        << "); the close-cancel path is not winning the race.";
+
+    // Wall-clock budget.  With the fix, this completes in a few seconds on
+    // localhost.  Without the fix, the worker queue fills after ~20
+    // iterations and every subsequent Open blocks for ~60s waiting for a
+    // paused op to stall-expire.
+    EXPECT_LT(elapsed_ms, 30'000)
+        << "Rapid open/read/close took " << elapsed_ms
+        << " ms; expected <30s.";
+}


### PR DESCRIPTION
Fix worker slot leak when File::Close() is called with an in-flight prefetch op

When XrdPfc closes a file while a prefetch GET is paused in libcurl waiting
for the next Read() call, the slot on the curl worker was not released until
the stall timeout fired.

The fix uses the existing Continue() mechanism to drive the cleanup through
normal worker paths rather than adding a separate cancellation channel.
Close() sets a cancel flag on the op and, if the op is currently paused,
calls Continue() with a one-byte buffer and a CancelResponseHandler. This
re-queues the op to the worker's continue queue. The worker then checks
IsCancelled() before unpausing: if set, it calls Fail(), removes the handle
from the curl multi handle directly (no curl_easy_pause needed), and
decrements running_handles — freeing the slot immediately.

The CancelResponseHandler forwards the resulting error status through
PrefetchDefaultHandler::HandleResponse() so that prefetch-disable logic
and metrics follow the same path as other prefetch failures.

Two new monitoring counters are added: CurlWorker::m_cancelled_ops
(reported as "cancelled_ops" in the worker JSON) and
File::m_prefetch_cancelled_count (reported as "cancelled" in the prefetch
JSON), making cancellations visible alongside the existing expired/failed
counters.