### PR TITLE
Make workers more configurable

### DIFF
--- a/src/XrdClCurl/XrdClCurlFactory.cc
+++ b/src/XrdClCurl/XrdClCurlFactory.cc
@@ -140,6 +140,20 @@ Factory::Initialize()
             m_log->Debug(kLogXrdClCurl, "Using %d threads for curl operations", num_threads);
         }
 
+        // The maximum number of in-flight curl operations per worker thread.
+        env->PutInt("CurlMaxOpsPerWorker", XrdClCurl::CurlWorker::m_default_max_ops);
+        env->ImportInt("CurlMaxOpsPerWorker", "XRD_CURLMAXOPSPERWORKER");
+        int max_ops_per_worker = XrdClCurl::CurlWorker::m_default_max_ops;
+        if (env->GetInt("CurlMaxOpsPerWorker", max_ops_per_worker)) {
+            if (max_ops_per_worker <= 0 || max_ops_per_worker > 10'000) {
+                m_log->Error(kLogXrdClCurl, "Invalid value for the maximum number of in-flight ops per worker (%d); using default value of %d", max_ops_per_worker, XrdClCurl::CurlWorker::m_default_max_ops);
+                max_ops_per_worker = XrdClCurl::CurlWorker::m_default_max_ops;
+                env->PutInt("CurlMaxOpsPerWorker", max_ops_per_worker);
+            }
+            m_log->Debug(kLogXrdClCurl, "Using %d in-flight ops per worker", max_ops_per_worker);
+        }
+        XrdClCurl::CurlWorker::SetMaxOps(max_ops_per_worker);
+
         // The stall timeout to use for transfer operations.
         env->PutInt("CurlStallTimeout", XrdClCurl::CurlOperation::GetDefaultStallTimeout());
         env->ImportInt("CurlStallTimeout", "XRD_CURLSTALLTIMEOUT");

--- a/src/XrdClCurl/XrdClCurlFactory.cc
+++ b/src/XrdClCurl/XrdClCurlFactory.cc
@@ -208,7 +208,7 @@ Factory::Initialize()
         auto &cache = XrdClCurl::VerbsCache::Instance();
 
         // Startup curl workers after we've set the configs to avoid race conditions
-        for (unsigned idx=0; idx<m_poll_threads; idx++) {
+        for (int idx=0; idx<num_threads; idx++) {
             auto wk = std::make_unique<XrdClCurl::CurlWorker>(m_queue, cache, m_log);
             auto wkp = wk.get();
             std::thread t(XrdClCurl::CurlWorker::RunStatic, wkp);

--- a/src/XrdClCurl/XrdClCurlUtil.cc
+++ b/src/XrdClCurl/XrdClCurlUtil.cc
@@ -56,6 +56,7 @@ using namespace XrdClCurl;
 
 thread_local std::vector<CURL*> HandlerQueue::m_handles;
 std::atomic<unsigned> CurlWorker::m_maintenance_period = 5;
+std::atomic<unsigned> CurlWorker::m_max_ops = CurlWorker::m_default_max_ops;
 std::vector<std::unique_ptr<XrdClCurl::CurlWorker>> CurlWorker::m_workers;
 std::mutex CurlWorker::m_workers_mutex;
 
@@ -1257,7 +1258,7 @@ CurlWorker::Run() {
             }
 		}
         // Consume from the shared new operation queue
-        while (running_handles < static_cast<int>(m_max_ops)) {
+        while (running_handles < static_cast<int>(m_max_ops.load(std::memory_order_relaxed))) {
             auto op = running_handles == 0 ? queue.Consume(std::chrono::seconds(1)) : queue.TryConsume();
             if (!op) {
                 break;

--- a/src/XrdClCurl/XrdClCurlWorker.hh
+++ b/src/XrdClCurl/XrdClCurlWorker.hh
@@ -71,6 +71,14 @@ public:
         m_maintenance_period.store(maint, std::memory_order_relaxed);
     }
 
+    // Change the per-worker cap on the number of in-flight curl operations.
+    static void SetMaxOps(unsigned max_ops) {
+        m_max_ops.store(max_ops, std::memory_order_relaxed);
+    }
+
+    // Default value for the per-worker cap on in-flight curl operations.
+    static constexpr unsigned m_default_max_ops = 50;
+
     static std::string GetMonitoringJson();
 
 private:
@@ -100,7 +108,7 @@ private:
     std::string m_x509_client_cert_file;
     std::string m_x509_client_key_file;
 
-    const static unsigned m_max_ops{20};
+    static std::atomic<unsigned> m_max_ops;
     static std::atomic<unsigned> m_maintenance_period;
 
     // File descriptor pair indicating shutdown is requested.


### PR DESCRIPTION
- Configure the # of requests per thread (bumping the default to 50, based on seeing issues in practice with pelicanfs).
- Fix setting number of workers so the config variable takes effect.