### PR TITLE
Fix redirect loop triggered by POSIXv2

### DIFF
--- a/src/XrdClCurl/XrdClCurlOps.cc
+++ b/src/XrdClCurl/XrdClCurlOps.cc
@@ -180,6 +180,7 @@ CurlOperation::CurlOperation(XrdCl::ResponseHandler *handler, const std::string 
     m_header_start(m_last_reset),
     m_conn_callout(callout),
     m_url(DavToHttp(url)),
+    m_effective_url(DavToHttp(url)),
     m_handler(handler),
     m_curl(nullptr, &curl_easy_cleanup),
     m_logger(logger)
@@ -316,21 +317,38 @@ CurlOperation::Redirect(std::string &target)
         return RedirectAction::Fail;
     }
     if (location.size() && location[0] == '/') { // hostname not included in the location - redirect to self.
-        std::string_view orig_url(m_url);
-        auto scheme_loc = orig_url.find("://");
+        // Resolve the host-relative Location against the *effective* (most recent)
+        // request URL, not the original target (m_url).  After a cross-host redirect
+        // the curl handle is talking to a different host than m_url; using m_url here
+        // would send the next request to the wrong host.  See issue reported at
+        // https://github.com/PelicanPlatform/xrdcl-pelican/issues/116.
+        std::string_view base_url(m_effective_url);
+        auto scheme_loc = base_url.find("://");
         if (scheme_loc == std::string_view::npos) {
             Fail(XrdCl::errErrorResponse, kXR_ServerError, "Server returned a location with unknown hostname");
             return RedirectAction::Fail;
         }
-        auto path_loc = orig_url.find('/', scheme_loc + 3);
+        auto path_loc = base_url.find('/', scheme_loc + 3);
         if (path_loc == std::string_view::npos) {
-            location = m_url + location;
+            location = std::string(base_url) + location;
         } else {
-            location = std::string(orig_url.substr(0, path_loc)) + location;
+            location = std::string(base_url.substr(0, path_loc)) + location;
         }
     }
+
+    // Redirects are not followed by libcurl so curl'own redirect limit never kicks in.
+    // Bound the reinvoke path to avoid potential redirect loops.
+    if (++m_redirect_count > m_max_redirects) {
+        m_logger->Warning(kLogXrdClCurl, "Request for %s exceeded the maximum number of redirects (%u)", m_url.c_str(), m_max_redirects);
+        Fail(XrdCl::errRedirectLimit, kXR_ServerError, "Exceeded the maximum number of redirects");
+        return RedirectAction::Fail;
+    }
+
     m_logger->Debug(kLogXrdClCurl, "Request for %s redirected to %s", m_url.c_str(), location.c_str());
     target = location;
+    // Track the effective URL so a subsequent host-relative Location resolves
+    // against this redirect target rather than the original request URL.
+    m_effective_url = location;
     curl_easy_setopt(m_curl.get(), CURLOPT_URL, location.c_str());
     int disable_x509;
     auto env = XrdCl::DefaultEnv::GetEnv();

--- a/src/XrdClCurl/XrdClCurlOps.hh
+++ b/src/XrdClCurl/XrdClCurlOps.hh
@@ -411,6 +411,16 @@ private:
 protected:
     void SetDone(bool has_failed) {m_done = true; m_has_failed.store(has_failed, std::memory_order_release);}
     const std::string m_url;
+
+    // The most recent URL.  Initialized to `m_url` and updated by `Redirect()`
+    // on each hop so host-relative Location headers resolve against the current
+    // target rather than `m_url`.
+    std::string m_effective_url;
+
+    // Number of redirects followed.
+    unsigned m_redirect_count{0};
+    static constexpr unsigned m_max_redirects{32};
+
     XrdCl::ResponseHandler *m_handler{nullptr};
     std::unique_ptr<CURL, void(*)(CURL *)> m_curl;
     HeaderParser m_headers;

--- a/tests/XrdClCurl/CMakeLists.txt
+++ b/tests/XrdClCurl/CMakeLists.txt
@@ -32,9 +32,22 @@ add_executable( xrdcl-curl-test
   VectorReadTest.cc
 )
 
+# Unit tests that link against XrdClCurl but need no running fixtures
+add_executable( xrdcl-curl-unit
+  RedirectTest.cc
+)
+
 target_link_libraries( xrdcl-test XrdClCurlTransferTest nlohmann_json::nlohmann_json GTest::gtest_main )
 target_link_libraries( xrdcl-connection-test XrdClCurlTransferTest nlohmann_json::nlohmann_json GTest::gtest_main )
 target_link_libraries( xrdcl-curl-test XrdClCurlTesting XrdClCurlTransferTest nlohmann_json::nlohmann_json GTest::gtest_main )
+target_link_libraries( xrdcl-curl-unit XrdClCurlTesting GTest::gtest_main )
+
+# Standalone unit tests that do not need a running federation
+gtest_add_tests( TARGET xrdcl-curl-unit TEST_LIST CurlUnitTests )
+set_tests_properties( ${CurlUnitTests}
+  PROPERTIES
+    ENVIRONMENT "LD_LIBRARY_PATH=${XRootD_LIB_DIR}"
+)
 
 gtest_add_tests( TARGET xrdcl-test TEST_LIST CurlClOnlyTests )
 set_tests_properties( ${CurlClOnlyTests}

--- a/tests/XrdClCurl/RedirectTest.cc
+++ b/tests/XrdClCurl/RedirectTest.cc
@@ -1,0 +1,123 @@
+/****************************************************************
+ *
+ * xrdcl-pelican implements an XRootD client plugin for interacting with the Pelican Platform
+ * Copyright (C) 2026 Morgridge Institute for Research
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ ***************************************************************/
+
+// Unit tests for CurlOperation::Redirect().
+//
+// See https://github.com/PelicanPlatform/xrdcl-pelican/issues/116 : a
+// host-relative Location header (one starting with '/') must be resolved
+// against the *effective* (most recent) request URL, not the *original*
+// target.  These tests exercise Redirect() directly, with no network I/O.
+
+#include "XrdClCurl/XrdClCurlOps.hh"
+
+#include <XrdCl/XrdClDefaultEnv.hh>
+#include <XrdCl/XrdClLog.hh>
+
+#include <gtest/gtest.h>
+
+using namespace XrdClCurl;
+
+namespace {
+
+// A minimal concrete CurlOperation so we can drive Redirect() directly.
+//
+// CurlOperation is abstract (Success()/GetVerb() are pure virtual) and its
+// response-header state (m_headers) is protected, so the test subclass both
+// provides the missing virtuals and exposes a helper to feed in a synthetic
+// redirect response.
+class TestRedirectOp final : public CurlOperation {
+public:
+    TestRedirectOp(const std::string &url, XrdCl::Log *log)
+        : CurlOperation(nullptr, url, timespec{30, 0}, log, nullptr, nullptr)
+    {
+        // Give the operation a real (if unconnected) curl handle so the
+        // CURLOPT_URL set inside Redirect() exercises the real code path.
+        m_curl.reset(curl_easy_init());
+    }
+
+    void Success() override {}
+    HttpVerb GetVerb() const override {return HttpVerb::GET;}
+
+    // Feed the operation a synthetic redirect response, the way libcurl's
+    // header callback would, one header line at a time.
+    void InjectRedirect(int status, const std::string &location) {
+        m_headers = HeaderParser();
+        m_headers.Parse("HTTP/1.1 " + std::to_string(status) + " Redirect\r\n");
+        m_headers.Parse("Location: " + location + "\r\n");
+        m_headers.Parse("\r\n");
+    }
+};
+
+XrdCl::Log *GetLog() {
+    return XrdCl::DefaultEnv::GetLog();
+}
+
+} // namespace
+
+// The regression test for issue #116: after an absolute cross-host redirect
+// (host-a -> host-b), a host-relative Location returned by host-b must resolve
+// against host-b, not the original host-a target.
+TEST(Redirect, HostRelativeLocationResolvedAgainstEffectiveUrl) {
+    TestRedirectOp op("https://host-a:443/namespace/file", GetLog());
+
+    // Step (a): host-a issues an absolute redirect to host-b.
+    op.InjectRedirect(307, "https://host-b:443/namespace/file");
+    std::string target;
+    ASSERT_EQ(op.Redirect(target), CurlOperation::RedirectAction::Reinvoke);
+    EXPECT_EQ(target, "https://host-b:443/namespace/file");
+
+    // Step (b): host-b returns a host-relative Location.  This must be resolved
+    // against the effective base (host-b), NOT the original target (host-a).
+    op.InjectRedirect(307, "/namespace/file/");
+    ASSERT_EQ(op.Redirect(target), CurlOperation::RedirectAction::Reinvoke);
+    EXPECT_EQ(target, "https://host-b:443/namespace/file/");
+}
+
+// A host-relative redirect with no prior cross-host hop still resolves against
+// the original target (the effective URL equals the original URL at that point).
+TEST(Redirect, HostRelativeLocationOnFirstHop) {
+    TestRedirectOp op("https://origin.example:8443/namespace", GetLog());
+
+    op.InjectRedirect(307, "/namespace/");
+    std::string target;
+    ASSERT_EQ(op.Redirect(target), CurlOperation::RedirectAction::Reinvoke);
+    EXPECT_EQ(target, "https://origin.example:8443/namespace/");
+}
+
+// The Pelican POSIX v2 ping-pong from issue #116: origin.example redirects
+// "/namespace" -> "/namespace/" (host-relative) while a cache in front keeps
+// bouncing the request.  Without a redirect cap on the manual reinvoke path
+// such a cycle is unbounded; the cap must eventually fail the operation.
+TEST(Redirect, RepeatedRedirectsAreCapped) {
+    TestRedirectOp op("https://origin.example:8443/namespace", GetLog());
+
+    // Drive a long chain of host-relative redirects; at some point the
+    // operation must give up rather than reinvoke forever.
+    bool capped = false;
+    for (int i = 0; i < 100; ++i) {
+        op.InjectRedirect(307, "/namespace/");
+        std::string target;
+        if (op.Redirect(target) == CurlOperation::RedirectAction::Fail) {
+            capped = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(capped) << "Redirect() never failed; the manual reinvoke path has no redirect cap";
+}

--- a/tests/XrdClPelican/CMakeLists.txt
+++ b/tests/XrdClPelican/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable( xrdcl-pelican-test
   CacheToken.cc
   ChecksumTest.cc
   DirectorTest.cc
+  RedirectIntegrationTest.cc
   RetryIntegrationTest.cc
   WritebackTest.cc
 )
@@ -65,8 +66,11 @@ set_tests_properties( ${PelicanTests}
 find_program(PELICAN_BIN pelican HINTS "${CMAKE_CURRENT_BINARY_DIR}")
 if( NOT PELICAN_BIN )
   # Example URL:
-  # https://dl.pelicanplatform.org/7.14.2/pelican_Linux_arm64.tar.gz
-  set( PELICAN_VERSION "7.14.2" )
+  # https://dl.pelicanplatform.org/7.25.0/pelican_Linux_arm64.tar.gz
+  #
+  # Version requirement bumped to v7.25.0 to grab POSIXv2 backend, allowing for
+  # a regression test on issue #116.
+  set( PELICAN_VERSION "7.25.0" )
   if( APPLE )
       set( SYS_NAME "Darwin" )
   else()
@@ -77,17 +81,17 @@ if( NOT PELICAN_BIN )
   else()
     set( SYS_PROC "x86_64" )
   endif()
-    
+
   set( PELICAN_URL "https://dl.pelicanplatform.org/${PELICAN_VERSION}/pelican_${SYS_NAME}_${SYS_PROC}.tar.gz" )
   set( PELICAN_HASH "000000000" )
   if( SYS_NAME STREQUAL "Darwin" AND SYS_PROC STREQUAL "x86_64" )
-    set( PELICAN_HASH "6ef9370f6c9e7fa8ec1aae197b7b18324ffdaecbad61e3754a49f5d4ce2b575d" )
+    set( PELICAN_HASH "5d635c7a2dec92cf8f739e9e816a2119ed5a7b9285ad78a94fcb67334dee7523" )
   elseif( SYS_NAME STREQUAL "Darwin" AND SYS_PROC STREQUAL "arm64" )
-    set( PELICAN_HASH "7e8f97ab8d364ed4e6a6e69324a8c7e6ab8cda8c85e9aba47f7f6a83ad124e1b" )
+    set( PELICAN_HASH "ba1c82c66abff4c56c85c714b0b08a13630adc223980939f377d43cc30714ded" )
   elseif( SYS_NAME STREQUAL "Linux" AND SYS_PROC STREQUAL "x86_64" )
-    set( PELICAN_HASH "e2aa7faa4b0727557185c5c81d594c62aa38adb76ddac9ec6580714d48cc06c4" )
+    set( PELICAN_HASH "30d1cdbb5d18ff7dbb80e21f805666601d81a14579c5f10d6a153f80b818122a" )
   elseif( SYS_NAME STREQUAL "Linux" AND SYS_PROC STREQUAL "arm64" )
-    set( PELICAN_HASH "a7d0d9226511c18bd17bcd3878d30c8629a062237610aba45f99dedb24d40097" )
+    set( PELICAN_HASH "03ce68ebf7ce5bbef35c6181988ccb63de2084536e7d5baa0d067651cfbbe726" )
   endif()
   file( DOWNLOAD "${PELICAN_URL}" "${CMAKE_CURRENT_BINARY_DIR}/pelican-v${PELICAN_VERSION}.tar.gz" EXPECTED_HASH "SHA256=${PELICAN_HASH}" )
   file( ARCHIVE_EXTRACT INPUT "${CMAKE_CURRENT_BINARY_DIR}/pelican-v${PELICAN_VERSION}.tar.gz" PATTERNS "pelican-${PELICAN_VERSION}/pelican" )

--- a/tests/XrdClPelican/RedirectIntegrationTest.cc
+++ b/tests/XrdClPelican/RedirectIntegrationTest.cc
@@ -1,0 +1,73 @@
+/****************************************************************
+ *
+ * xrdcl-pelican implements an XRootD client plugin for interacting with the Pelican Platform
+ * Copyright (C) 2026 Morgridge Institute for Research
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ ***************************************************************/
+
+//
+// Integration test for https://github.com/PelicanPlatform/xrdcl-pelican/issues/116 :
+// a host-relative redirect Location must be resolved against the *effective*
+// (most recent) request URL, not the original one.
+//
+// In-the-wild trigger: a Pelican origin running the POSIX backend answers a
+// request for a federation-prefix path WITHOUT a trailing slash (e.g.
+// "/test-public") with a host-relative redirect (Location: "/test-public/").
+// This is produced by Gin's default RedirectTrailingSlash: the origin's web
+// engine registers the export as the route group "/test-public" with a
+// "/*path" wildcard child, so a request to the bare prefix "/test-public" has
+// no exact match and Gin redirects it to "/test-public/".  (A subdirectory such
+// as "/test-public/subdir" is matched by the wildcard and is NOT redirected --
+// which is why this test lists the namespace root specifically.)
+//
+// To exhibit the bug, the client must reach that origin via a prior cross-host
+// redirect: the request is issued to the director (PELICAN_URL), which redirects
+// to the origin (a different host) before the origin emits its host-relative
+// Location.  Before the fix, the client resolved "/test-public/" against the
+// director (the original m_url), reissued the request to the wrong host, and the
+// listing failed (in the worst case ping-ponging until a timeout).  After the
+// fix it resolves against the origin (the effective URL) and the listing
+// succeeds.
+//
+
+#include "../XrdClCurlCommon/TransferTest.hh"
+
+#include <XrdCl/XrdClFileSystem.hh>
+
+#include <gtest/gtest.h>
+
+class PelicanRedirectFixture : public TransferFixture {};
+
+// List the federation-prefix root with no trailing slash, via the director, so
+// the director -> origin cross-host hop precedes the origin's host-relative
+// trailing-slash redirect.  "/test-public" is a public, listable export in the
+// test federation, so no token is required.
+TEST_F(PelicanRedirectFixture, ListNamespaceRootWithoutTrailingSlash) {
+    auto pelican_url = GetEnv("PELICAN_URL");
+    XrdCl::FileSystem fs{XrdCl::URL(pelican_url)};
+
+    XrdCl::DirectoryList *listing{nullptr};
+    auto st = fs.DirList("/test-public", XrdCl::DirListFlags::Stat, listing,
+                         static_cast<uint16_t>(10));
+    ASSERT_TRUE(st.IsOK())
+        << "DirList of the namespace root without a trailing slash failed; the "
+           "origin's host-relative redirect was likely resolved against the "
+           "director instead of the origin (issue #116): " << st.ToString();
+    ASSERT_NE(listing, nullptr);
+    EXPECT_GT(listing->GetSize(), 0u)
+        << "Expected a non-empty listing of the /test-public namespace root";
+    delete listing;
+}


### PR DESCRIPTION
The POSIXv2 backend will redirect stats on the top level namespace (`/test-public`) to have a trailing slash (`/test-public/`).  The client incorrectly applied the relative redirect (`/test-public`) to the original director URL, producing a URL like `https://director.com/test-public/`).  Unfortunately, the director would then generate another redirect to the same origin looking like `https://origin.com/test-public` which, subsequently, caused us to go back to the beginning.

The PR:
- Adds a regression test for Pelican.
- Corrects the behavior for relative redirects in XrdClCurl.
- Adds a limit to number of redirects, hardcoded to 32.