### PR TITLE
Improve usage of error status code API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,24 @@ int main(void) {return 0;}"
 HAVE_XRDCL_IFACE6)
 
 #
+# XRootD 6 added the XrdOss::getErrMsg() virtual (and the surrounding
+# XrdOucECMsg / XRDOSS_HASXERT "extended error text" machinery) that lets an OSS
+# plug-in hand a detailed error string up to XrdOfs and out the server's HTTP
+# response.  Earlier releases lack the virtual, so any override of it fails to
+# compile.  This is the mechanism that carries an XrdClCurl error string into a
+# proxy/cache's HTTP error body; see reference/error-string-propagation.md.
+#
+CHECK_SOURCE_COMPILES(CXX
+"#include <XrdOss/XrdOss.hh>
+#include <string>
+class TestDF final : public XrdOssDF {
+public:
+    bool getErrMsg(std::string& eText) override {eText = \"x\"; return true;}
+};
+int main(void) {return 0;}"
+HAVE_XROOTD_OSS_GETERRMSG)
+
+#
 # Apply the XRootD feature-detection macros globally.
 #
 if (HAVE_XPROTOCOL_TIMEREXPIRED)
@@ -55,6 +73,9 @@ if (HAVE_XPROTOCOL_TIMEREXPIRED)
 endif()
 if (HAVE_XRDCL_IFACE6)
   add_compile_definitions(HAVE_XRDCL_IFACE6)
+endif()
+if (HAVE_XROOTD_OSS_GETERRMSG)
+  add_compile_definitions(HAVE_XROOTD_OSS_GETERRMSG)
 endif()
 
 # Upstream XRootD merged the XrdClCurl and XrdClS3 plugins into its own tree

--- a/src/XrdClCurl/XrdClCurlOpListdir.cc
+++ b/src/XrdClCurl/XrdClCurlOpListdir.cc
@@ -165,6 +165,16 @@ CurlListdirOp::ParseResponse(tinyxml2::XMLElement *response)
 }
 
 void
+CurlListdirOp::Fail(uint16_t errCode, uint32_t errNum, const std::string &msg)
+{
+    // The listing is a PROPFIND; on an error response m_response holds the
+    // origin's error body.  Fold it into the message so it propagates upstream
+    // (on XRootD >= 6, out the proxy/cache's HTTP error response).  See
+    // reference/error-string-propagation.md.
+    CurlOperation::Fail(errCode, errNum, AppendServerError(msg, m_response));
+}
+
+void
 CurlListdirOp::Success()
 {
     SetDone(false);

--- a/src/XrdClCurl/XrdClCurlOpOpen.cc
+++ b/src/XrdClCurl/XrdClCurlOpOpen.cc
@@ -98,7 +98,9 @@ CurlOpenOp::Fail(uint16_t errCode, uint32_t errNum, const std::string &msg)
         SuccessImpl(false);
         return;
     }
-    CurlOperation::Fail(errCode, errNum, msg);
+    // Delegate to CurlStatOp::Fail so a PROPFIND error body (the origin's
+    // detailed error text) is folded into the propagated message.
+    CurlStatOp::Fail(errCode, errNum, msg);
 }
 
 void CurlPrefetchOpenOp::Pause()

--- a/src/XrdClCurl/XrdClCurlOpQuery.cc
+++ b/src/XrdClCurl/XrdClCurlOpQuery.cc
@@ -23,6 +23,8 @@
 #include <XrdCl/XrdClFileSystem.hh>
 #include <XrdCl/XrdClLog.hh>
 
+#include <cerrno>
+
 using namespace XrdClCurl;
 
 void CurlQueryOp::Success()
@@ -41,6 +43,8 @@ void CurlQueryOp::Success()
     }
     else {
         m_logger->Error(kLogXrdClCurl, "Invalid information query type code");
-        Fail(XrdCl::errInvalidArgs, XrdCl::errErrorResponse, "Unsupported query code");
+        // errNo must be a POSIX errno here (issue #117); errErrorResponse (400) is
+        // an XrdCl error code, not an errno.  errInvalidArgs maps to EINVAL.
+        Fail(XrdCl::errInvalidArgs, EINVAL, "Unsupported query code");
     }
 }

--- a/src/XrdClCurl/XrdClCurlOpRead.cc
+++ b/src/XrdClCurl/XrdClCurlOpRead.cc
@@ -165,12 +165,19 @@ CurlReadOp::Fail(uint16_t errCode, uint32_t errNum, const std::string &msg)
     auto log_target = ReadTargetForLog(m_url);
     SetDone(true);
     if (m_handler == nullptr && m_default_handler == nullptr) {return;}
+    // The body of an HTTP error response from the origin (captured into
+    // m_err_msg by Write() whenever the status code is >= 300) usually carries
+    // the most actionable diagnostic.  Surface it in the XRootDStatus message so
+    // it can propagate upstream: when this plugin backs an XRootD >= 6 proxy or
+    // cache, that text is forwarded into the HTTP error the server returns to its
+    // own client (see reference/error-string-propagation.md).
     if (!custom_msg.empty()) {
         m_logger->Debug(kLogXrdClCurl, "curl read operation for %s at offset %llu failed with message: %s%s", log_target.c_str(), static_cast<long long unsigned>(m_op.first), msg.c_str(), m_err_msg.empty() ? "" : (", server message: " + m_err_msg).c_str());
         custom_msg += " (read operation for " + log_target + " at offset " + std::to_string(static_cast<long long unsigned>(m_op.first)) + ")";
     } else {
         m_logger->Debug(kLogXrdClCurl, "curl read operation for %s at offset %llu failed with status code %d%s", log_target.c_str(), static_cast<long long unsigned>(m_op.first), errNum, m_err_msg.empty() ? "" : (", server message: " + m_err_msg).c_str());
     }
+    custom_msg = AppendServerError(custom_msg, m_err_msg);
     auto status = new XrdCl::XRootDStatus(XrdCl::stError, errCode, errNum, custom_msg);
     auto handle = m_handler;
     m_handler = nullptr;

--- a/src/XrdClCurl/XrdClCurlOpStat.cc
+++ b/src/XrdClCurl/XrdClCurlOpStat.cc
@@ -205,6 +205,17 @@ void CurlStatOp::Success()
 }
 
 void
+CurlStatOp::Fail(uint16_t errCode, uint32_t errNum, const std::string &msg)
+{
+    // When the stat is performed via PROPFIND, the body of an error response
+    // (captured in m_response) carries the origin's detailed error text.  Fold
+    // it into the XRootDStatus message so it can propagate upstream; on XRootD
+    // >= 6 a proxy/cache forwards this into its own HTTP error response.  See
+    // reference/error-string-propagation.md.
+    CurlOperation::Fail(errCode, errNum, AppendServerError(msg, m_response));
+}
+
+void
 CurlStatOp::SuccessImpl(bool returnObj)
 {
     SetDone(false);

--- a/src/XrdClCurl/XrdClCurlOps.cc
+++ b/src/XrdClCurl/XrdClCurlOps.cc
@@ -37,8 +37,52 @@
 #include <sys/random.h>
 #endif
 #include <utility>
+#include <algorithm>
 
 using namespace XrdClCurl;
+
+std::string
+XrdClCurl::SanitizeServerError(const std::string &body)
+{
+    constexpr size_t kMaxLen = 1024;
+    std::string out;
+    out.reserve(std::min(body.size(), kMaxLen));
+    for (char c : body) {
+        if (c == '\r' || c == '\n' || c == '\t' || c == ' ') {
+            if (!out.empty() && out.back() != ' ') {
+                out.push_back(' ');
+            }
+        } else if (static_cast<unsigned char>(c) < 0x20) {
+            continue; // drop other control characters
+        } else {
+            out.push_back(c);
+        }
+        if (out.size() >= kMaxLen) {
+            break;
+        }
+    }
+    while (!out.empty() && out.back() == ' ') {
+        out.pop_back();
+    }
+    auto start = out.find_first_not_of(' ');
+    if (start == std::string::npos) {
+        return std::string();
+    }
+    return out.substr(start);
+}
+
+std::string
+XrdClCurl::AppendServerError(const std::string &msg, const std::string &rawBody)
+{
+    std::string server_msg = SanitizeServerError(rawBody);
+    if (server_msg.empty()) {
+        return msg;
+    }
+    if (msg.empty()) {
+        return server_msg;
+    }
+    return msg + "; origin response: " + server_msg;
+}
 
 std::chrono::steady_clock::duration CurlOperation::m_stall_interval{CurlOperation::m_default_stall_interval};
 int CurlOperation::m_minimum_transfer_rate{CurlOperation::m_default_minimum_rate};

--- a/src/XrdClCurl/XrdClCurlOps.cc
+++ b/src/XrdClCurl/XrdClCurlOps.cc
@@ -433,7 +433,8 @@ CurlOperation::StartConnectionCallout(std::string &err)
 {
     if ((m_conn_callout_listener = m_callout->BeginCallout(err, m_header_expiry)) == -1) {
         err = "Failed to start a callout for a socket connection: " + err;
-        Fail(XrdCl::errInternal, 1, err.c_str());
+        // errNo must be a POSIX errno here (issue #117), not the literal 1 (EPERM).
+        Fail(XrdCl::errInternal, EIO, err.c_str());
         return false;
     }
     return true;

--- a/src/XrdClCurl/XrdClCurlOps.hh
+++ b/src/XrdClCurl/XrdClCurlOps.hh
@@ -63,6 +63,19 @@ class ResponseInfo;
 // `XErrorCode` (kXR_*), or libcurl's CURLcode.
 constexpr uint32_t kPrefetchCancelledOnClose = 0x4F434C53; // "OCLS"
 
+// Sanitize an HTTP error-response body captured from the origin so it can be
+// embedded into an XRootDStatus message: collapse runs of whitespace/newlines
+// into a single space, drop other control characters, and cap the length so an
+// oversized or hostile origin response cannot bloat the propagated message.
+// Used by the per-operation Fail() helpers so the origin's detailed error text
+// can travel up the stack (and, on XRootD >= 6, out a proxy/cache's HTTP error
+// response).  See reference/error-string-propagation.md.
+std::string SanitizeServerError(const std::string &body);
+
+// Append a sanitized origin error-response body to a high-level failure message.
+// Returns msg unchanged when the body is empty (after sanitizing).
+std::string AppendServerError(const std::string &msg, const std::string &rawBody);
+
 class CurlOperation {
 public:
     using HeaderList = std::vector<std::pair<std::string, std::string>>;
@@ -486,6 +499,7 @@ public:
 
     bool Setup(CURL *curl, CurlWorker &) override;
     void Success() override;
+    void Fail(uint16_t errCode, uint32_t errNum, const std::string &msg) override;
     RedirectAction Redirect(std::string &target) override;
     void ReleaseHandle() override;
 
@@ -799,6 +813,7 @@ public:
 
     bool Setup(CURL *curl, CurlWorker &) override;
     void Success() override;
+    void Fail(uint16_t errCode, uint32_t errNum, const std::string &msg) override;
     void ReleaseHandle() override;
 
     virtual HttpVerb GetVerb() const override {return HttpVerb::PROPFIND;}

--- a/src/XrdClCurl/XrdClCurlUtil.cc
+++ b/src/XrdClCurl/XrdClCurlUtil.cc
@@ -188,7 +188,11 @@ std::pair<uint16_t, uint32_t> XrdClCurl::HTTPStatusConvert(unsigned status) {
         case 511: // Network Authentication Required
             return std::make_pair(XrdCl::errErrorResponse, kXR_ServerError);
     }
-    return std::make_pair(XrdCl::errUnknown, status);
+    // Unrecognized status.  `code` is not errErrorResponse, so the errNo slot is
+    // interpreted verbatim as a POSIX errno by XrdPosixMap::Result(); the HTTP
+    // status is NOT a valid errno, so use a generic I/O error instead.  See
+    // https://github.com/PelicanPlatform/xrdcl-pelican/issues/117.
+    return std::make_pair(XrdCl::errUnknown, EIO);
 }
 
 std::pair<uint16_t, uint32_t> CurlCodeConvert(CURLcode res) {
@@ -235,27 +239,32 @@ std::pair<uint16_t, uint32_t> CurlCodeConvert(CURLcode res) {
             return std::make_pair(XrdCl::errNotSupported, ENOSYS);
         case CURLE_FAILED_INIT:
             return std::make_pair(XrdCl::errInternal, 0);
+        // NOTE: the errNo slot must be a POSIX errno (or 0) whenever `code` is
+        // not errErrorResponse, since XrdPosixMap::Result() uses it verbatim as
+        // the errno on the proxy/cache read path.  The raw CURLcode `res` is NOT
+        // a valid errno, so the arms below pair `code` with a real errno.  See
+        // https://github.com/PelicanPlatform/xrdcl-pelican/issues/117.
         case CURLE_URL_MALFORMAT:
-            return std::make_pair(XrdCl::errInvalidArgs, res);
+            return std::make_pair(XrdCl::errInvalidArgs, EINVAL);
         //case CURLE_WEIRD_SERVER_REPLY:
         //case CURLE_HTTP2:
         //case CURLE_HTTP2_STREAM:
-            return std::make_pair(XrdCl::errCorruptedHeader, res);
+            return std::make_pair(XrdCl::errCorruptedHeader, EPROTO);
         case CURLE_PARTIAL_FILE:
-            return std::make_pair(XrdCl::errDataError, res);
+            return std::make_pair(XrdCl::errDataError, EIO);
         // These two errors indicate a failure in the callback.  That
         // should generate their own failures, meaning this should never
         // get use.
         case CURLE_READ_ERROR:
         case CURLE_WRITE_ERROR:
-            return std::make_pair(XrdCl::errInternal, res);
+            return std::make_pair(XrdCl::errInternal, EIO);
         case CURLE_RANGE_ERROR:
         case CURLE_BAD_CONTENT_ENCODING:
-            return std::make_pair(XrdCl::errNotSupported, res);
+            return std::make_pair(XrdCl::errNotSupported, ENOTSUP);
         case CURLE_TOO_MANY_REDIRECTS:
-            return std::make_pair(XrdCl::errRedirectLimit, res);
+            return std::make_pair(XrdCl::errRedirectLimit, ELOOP);
         default:
-            return std::make_pair(XrdCl::errUnknown, res);
+            return std::make_pair(XrdCl::errUnknown, EIO);
     }
 }
 
@@ -1331,7 +1340,8 @@ CurlWorker::Run() {
             auto mres = curl_multi_add_handle(multi_handle, curl);
             if (mres != CURLM_OK) {
                 m_logger->Debug(kLogXrdClCurl, "Unable to add operation to the curl multi-handle");
-                op->Fail(XrdCl::errInternal, mres, "Unable to add operation to the curl multi-handle");
+                // mres is a CURLMcode, not a POSIX errno (issue #117); use EIO.
+                op->Fail(XrdCl::errInternal, EIO, "Unable to add operation to the curl multi-handle");
                 OpRecord(*op, OpKind::Error);
                 continue;
             }
@@ -1389,7 +1399,8 @@ CurlWorker::Run() {
                         }
                     }
 
-                    iter->second.first->Fail(XrdCl::errConnectionError, 1, "Timeout: connection never provided for request");
+                    // errNo must be a POSIX errno here (issue #117), not the literal 1 (EPERM).
+                    iter->second.first->Fail(XrdCl::errConnectionError, ECONNREFUSED, "Timeout: connection never provided for request");
                     iter->second.first->ReleaseHandle();
                     OpRecord(*(iter->second.first), OpKind::ConncallTimeout);
                     m_op_map.erase(entry.second);
@@ -1657,7 +1668,8 @@ CurlWorker::Run() {
                                     auto mres = curl_multi_add_handle(multi_handle, curl);
                                     if (mres != CURLM_OK) {
                                         m_logger->Debug(kLogXrdClCurl, "Unable to add OPTIONS operation to the curl multi-handle: %s", curl_multi_strerror(mres));
-                                        op->Fail(XrdCl::errInternal, mres, "Unable to add OPTIONS operation to the curl multi-handle");
+                                        // mres is a CURLMcode, not a POSIX errno (issue #117); use EIO.
+                                        op->Fail(XrdCl::errInternal, EIO, "Unable to add OPTIONS operation to the curl multi-handle");
                                         OpRecord(*new_op, OpKind::Error);
                                         break;
                                     }
@@ -1849,7 +1861,8 @@ CurlWorker::Run() {
 
     for (auto map_entry : m_op_map) {
         if (mres) {
-            map_entry.second.first->Fail(XrdCl::errInternal, mres, curl_multi_strerror(mres));
+            // mres is a CURLMcode, not a POSIX errno (issue #117); use EIO.
+            map_entry.second.first->Fail(XrdCl::errInternal, EIO, curl_multi_strerror(mres));
             OpRecord(*map_entry.second.first, OpKind::Error);
         }
         if (multi_handle && map_entry.first) curl_multi_remove_handle(multi_handle, map_entry.first);

--- a/tests/XrdClCurl/CMakeLists.txt
+++ b/tests/XrdClCurl/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable( xrdcl-curl-test
 # Unit tests that link against XrdClCurl but need no running fixture.
 add_executable( xrdcl-curl-unit
   ErrnoConvertTest.cc
+  ErrorMessageTest.cc
   RedirectTest.cc
 )
 

--- a/tests/XrdClCurl/CMakeLists.txt
+++ b/tests/XrdClCurl/CMakeLists.txt
@@ -32,17 +32,18 @@ add_executable( xrdcl-curl-test
   VectorReadTest.cc
 )
 
-# Unit tests that link against XrdClCurl but need no running fixtures
+# Unit tests that link against XrdClCurl but need no running fixture.
 add_executable( xrdcl-curl-unit
+  ErrnoConvertTest.cc
   RedirectTest.cc
 )
 
 target_link_libraries( xrdcl-test XrdClCurlTransferTest nlohmann_json::nlohmann_json GTest::gtest_main )
 target_link_libraries( xrdcl-connection-test XrdClCurlTransferTest nlohmann_json::nlohmann_json GTest::gtest_main )
 target_link_libraries( xrdcl-curl-test XrdClCurlTesting XrdClCurlTransferTest nlohmann_json::nlohmann_json GTest::gtest_main )
-target_link_libraries( xrdcl-curl-unit XrdClCurlTesting GTest::gtest_main )
+target_link_libraries( xrdcl-curl-unit XrdClCurlTesting CURL::libcurl GTest::gtest_main )
 
-# Standalone unit tests that do not need a running federation
+# Standalone unit tests do not need the curl federation fixture; always register.
 gtest_add_tests( TARGET xrdcl-curl-unit TEST_LIST CurlUnitTests )
 set_tests_properties( ${CurlUnitTests}
   PROPERTIES

--- a/tests/XrdClCurl/ErrnoConvertTest.cc
+++ b/tests/XrdClCurl/ErrnoConvertTest.cc
@@ -1,0 +1,127 @@
+/****************************************************************
+ *
+ * xrdcl-pelican implements an XRootD client plugin for interacting with the Pelican Platform
+ * Copyright (C) 2026 Morgridge Institute for Research
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ ***************************************************************/
+
+//
+// Unit tests for the error-conversion helpers, enforcing the XRootDStatus
+// errNo contract described in
+// https://github.com/PelicanPlatform/xrdcl-pelican/issues/117 :
+//
+//   * if code == errErrorResponse, errNo must be a kXR_* server error code
+//     (XrdPosixMap maps it through XProtocol::toErrno());
+//   * for every other code, errNo must be a real POSIX errno (or 0), because
+//     XrdPosixMap::Result() uses it verbatim as the errno.
+//
+// Storing a raw CURLcode / HTTP status / XrdCl err* constant in the errNo slot
+// (the original defect) is what these tests guard against.
+//
+
+#include "XrdClCurl/XrdClCurlUtil.hh"
+
+#include <XrdCl/XrdClStatus.hh>
+#include <XProtocol/XProtocol.hh>
+
+#include <curl/curl.h>
+#include <gtest/gtest.h>
+
+#include <cerrno>
+
+// CurlCodeConvert() has external linkage but is an internal helper not exposed
+// through a public header; declare it here for white-box testing.  (Its sibling
+// HTTPStatusConvert() is declared in XrdClCurlUtil.hh.)
+std::pair<uint16_t, uint32_t> CurlCodeConvert(CURLcode res);
+
+namespace {
+
+// kXR_* server error codes occupy [kXR_ArgInvalid, ...) = [3000, 3100).  Used to
+// distinguish a (valid) kXR_* code from a (valid) POSIX errno, which is small.
+bool LooksLikeKxrCode(uint32_t v) { return v >= 3000 && v < 3100; }
+
+// A POSIX errno is a small positive value (or 0 meaning "defer to mapCode").
+bool LooksLikePosixErrno(uint32_t v) { return v < 256; }
+
+// Assert that a (code, errNo) pair honors the issue #117 contract.
+void ExpectContract(const std::pair<uint16_t, uint32_t> &p, const char *what) {
+    if (p.first == XrdCl::errErrorResponse) {
+        EXPECT_TRUE(LooksLikeKxrCode(p.second))
+            << what << ": errErrorResponse requires a kXR_* code in errNo, got " << p.second;
+    } else {
+        EXPECT_TRUE(LooksLikePosixErrno(p.second))
+            << what << ": code " << p.first
+            << " (!= errErrorResponse) requires a POSIX errno in errNo, got " << p.second;
+    }
+}
+
+} // namespace
+
+// The motivating bug: CURLE_PARTIAL_FILE (value 18) must not leak 18 into errNo,
+// where it would be reinterpreted as EXDEV ("invalid cross-device link").
+TEST(ErrnoConvert, PartialFileIsNotExdev) {
+    auto p = CurlCodeConvert(CURLE_PARTIAL_FILE);
+    EXPECT_NE(p.first, XrdCl::errErrorResponse);
+    EXPECT_EQ(p.second, static_cast<uint32_t>(EIO));
+    EXPECT_NE(p.second, static_cast<uint32_t>(CURLE_PARTIAL_FILE));
+}
+
+// Every CURLcode the converter might see must satisfy the contract: no raw
+// CURLcode ends up in the errNo slot paired with a non-errErrorResponse code.
+TEST(ErrnoConvert, CurlCodeConvertHonorsContract) {
+    for (int i = 0; i <= CURL_LAST; ++i) {
+        auto res = static_cast<CURLcode>(i);
+        auto p = CurlCodeConvert(res);
+        ExpectContract(p, curl_easy_strerror(res));
+    }
+    // Explicit anchors for every arm that previously leaked the raw CURLcode
+    // into errNo.  A raw CURLcode is numerically small, so it would also satisfy
+    // the generic contract check above; these pin the specific errno instead.
+    EXPECT_EQ(CurlCodeConvert(CURLE_URL_MALFORMAT).second, static_cast<uint32_t>(EINVAL));
+    EXPECT_EQ(CurlCodeConvert(CURLE_PARTIAL_FILE).second, static_cast<uint32_t>(EIO));
+    EXPECT_EQ(CurlCodeConvert(CURLE_READ_ERROR).second, static_cast<uint32_t>(EIO));
+    EXPECT_EQ(CurlCodeConvert(CURLE_WRITE_ERROR).second, static_cast<uint32_t>(EIO));
+    EXPECT_EQ(CurlCodeConvert(CURLE_RANGE_ERROR).second, static_cast<uint32_t>(ENOTSUP));
+    EXPECT_EQ(CurlCodeConvert(CURLE_BAD_CONTENT_ENCODING).second, static_cast<uint32_t>(ENOTSUP));
+    EXPECT_EQ(CurlCodeConvert(CURLE_TOO_MANY_REDIRECTS).second, static_cast<uint32_t>(ELOOP));
+    EXPECT_EQ(CurlCodeConvert(CURLE_UNSUPPORTED_PROTOCOL).first, XrdCl::errNotSupported);
+    // The default arm (an unmapped CURLcode) yields a generic I/O errno, not the
+    // raw code.
+    EXPECT_EQ(CurlCodeConvert(CURLE_LDAP_CANNOT_BIND).first, XrdCl::errUnknown);
+    EXPECT_EQ(CurlCodeConvert(CURLE_LDAP_CANNOT_BIND).second, static_cast<uint32_t>(EIO));
+    // CURLE_OK is the no-error pair.
+    EXPECT_EQ(CurlCodeConvert(CURLE_OK).first, XrdCl::errNone);
+    EXPECT_EQ(CurlCodeConvert(CURLE_OK).second, 0u);
+}
+
+// Every HTTP status code must satisfy the contract: explicit arms pair
+// errErrorResponse with a kXR_* code, and the default arm must NOT leak the raw
+// HTTP status into the errNo slot.
+TEST(ErrnoConvert, HttpStatusConvertHonorsContract) {
+    for (unsigned status = 100; status < 600; ++status) {
+        auto p = XrdClCurl::HTTPStatusConvert(status);
+        ExpectContract(p, ("HTTP " + std::to_string(status)).c_str());
+    }
+    // An unmapped error status must not surface the status number as the errno.
+    auto p = XrdClCurl::HTTPStatusConvert(599);
+    EXPECT_NE(p.first, XrdCl::errErrorResponse);
+    EXPECT_EQ(p.second, static_cast<uint32_t>(EIO));
+    EXPECT_NE(p.second, 599u);
+
+    // A representative explicit arm still maps to a kXR_* code.
+    EXPECT_EQ(XrdClCurl::HTTPStatusConvert(404).first, XrdCl::errErrorResponse);
+    EXPECT_EQ(XrdClCurl::HTTPStatusConvert(404).second, static_cast<uint32_t>(kXR_NotFound));
+}

--- a/tests/XrdClCurl/ErrorMessageTest.cc
+++ b/tests/XrdClCurl/ErrorMessageTest.cc
@@ -1,0 +1,144 @@
+/****************************************************************
+ *
+ * xrdcl-pelican implements an XRootD client plugin for interacting with the Pelican Platform
+ * Copyright (C) 2026 Morgridge Institute for Research
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ ***************************************************************/
+
+// Unit tests for error-string propagation out of CurlReadOp.
+//
+// See https://github.com/PelicanPlatform/xrdcl-pelican/issues/117 and
+// reference/error-string-propagation.md.  When the origin returns an HTTP
+// error, CurlReadOp::Write() captures the response body into m_err_msg.  These
+// tests verify CurlReadOp::Fail() folds that captured body into the
+// XRootDStatus error message so it can travel up the XrdCl interface (and, on
+// XRootD >= 6, out the proxy/cache's own HTTP error response).
+//
+// These tests drive CurlReadOp directly, with no network I/O.
+
+#include "XrdClCurl/XrdClCurlOps.hh"
+
+#include <XrdCl/XrdClDefaultEnv.hh>
+#include <XrdCl/XrdClLog.hh>
+#include <XrdCl/XrdClXRootDResponses.hh>
+#include <XProtocol/XProtocol.hh>
+
+#include <gtest/gtest.h>
+
+using namespace XrdClCurl;
+
+namespace {
+
+// A ResponseHandler that records the delivered XRootDStatus so the test can
+// inspect the error message the operation produced.
+class CapturingHandler final : public XrdCl::ResponseHandler {
+public:
+    void HandleResponse(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response) override {
+        m_called = true;
+        m_code = status->code;
+        m_errNo = status->errNo;
+        m_message = status->GetErrorMessage();
+        delete status;
+        delete response;
+    }
+
+    bool m_called{false};
+    uint16_t m_code{0};
+    uint32_t m_errNo{0};
+    std::string m_message;
+};
+
+// A minimal concrete CurlReadOp that lets the test stand in for the data the
+// libcurl write callback would have captured from an origin error response.
+class TestReadOp final : public CurlReadOp {
+public:
+    TestReadOp(XrdCl::ResponseHandler *handler, XrdCl::Log *log)
+        : CurlReadOp(handler, nullptr, "https://origin.example:8443/test/file",
+                     timespec{30, 0}, {0, 4096}, nullptr, 0, log, nullptr, nullptr)
+    {}
+
+    // Stand in for the body Write() copies into m_err_msg on an HTTP error.
+    void SetCapturedErrorBody(const std::string &body) { m_err_msg = body; }
+};
+
+XrdCl::Log *GetLog() {
+    return XrdCl::DefaultEnv::GetLog();
+}
+
+} // namespace
+
+// The captured origin error body must appear in the propagated error message.
+TEST(ErrorMessage, ReadFailureIncludesOriginResponseBody) {
+    CapturingHandler handler;
+    TestReadOp op(&handler, GetLog());
+
+    op.SetCapturedErrorBody("Origin refused widget 42: storage backend offline");
+    op.Fail(XrdCl::errErrorResponse, kXR_ServerError, "Internal Server Error");
+
+    ASSERT_TRUE(handler.m_called);
+    EXPECT_EQ(handler.m_code, XrdCl::errErrorResponse);
+    EXPECT_EQ(handler.m_errNo, static_cast<uint32_t>(kXR_ServerError));
+    // Both the high-level reason and the origin's detailed body should be present.
+    EXPECT_NE(handler.m_message.find("Internal Server Error"), std::string::npos)
+        << handler.m_message;
+    EXPECT_NE(handler.m_message.find("Origin refused widget 42: storage backend offline"),
+              std::string::npos)
+        << handler.m_message;
+}
+
+// Multi-line / padded origin bodies are collapsed to a single tidy line.
+TEST(ErrorMessage, OriginResponseBodyIsSanitized) {
+    CapturingHandler handler;
+    TestReadOp op(&handler, GetLog());
+
+    op.SetCapturedErrorBody("  Unable to open /test/file;\r\n   permission denied\n");
+    op.Fail(XrdCl::errErrorResponse, kXR_NotAuthorized, "Forbidden");
+
+    ASSERT_TRUE(handler.m_called);
+    EXPECT_NE(handler.m_message.find("Unable to open /test/file; permission denied"),
+              std::string::npos)
+        << handler.m_message;
+    // No embedded carriage returns or newlines should survive.
+    EXPECT_EQ(handler.m_message.find('\n'), std::string::npos) << handler.m_message;
+    EXPECT_EQ(handler.m_message.find('\r'), std::string::npos) << handler.m_message;
+}
+
+// With no captured body, the message is just the high-level reason (no dangling
+// "; origin response:" suffix).
+TEST(ErrorMessage, ReadFailureWithoutBodyHasNoOriginSuffix) {
+    CapturingHandler handler;
+    TestReadOp op(&handler, GetLog());
+
+    op.Fail(XrdCl::errErrorResponse, kXR_NotFound, "Not Found");
+
+    ASSERT_TRUE(handler.m_called);
+    EXPECT_NE(handler.m_message.find("Not Found"), std::string::npos) << handler.m_message;
+    EXPECT_EQ(handler.m_message.find("origin response"), std::string::npos) << handler.m_message;
+}
+
+// An oversized origin body must be capped rather than copied verbatim.
+TEST(ErrorMessage, OriginResponseBodyIsLengthCapped) {
+    CapturingHandler handler;
+    TestReadOp op(&handler, GetLog());
+
+    op.SetCapturedErrorBody(std::string(8192, 'x'));
+    op.Fail(XrdCl::errErrorResponse, kXR_ServerError, "Internal Server Error");
+
+    ASSERT_TRUE(handler.m_called);
+    // The sanitizer caps the embedded body at 1024 bytes; the whole message must
+    // therefore stay comfortably bounded.
+    EXPECT_LT(handler.m_message.size(), static_cast<size_t>(2048)) << handler.m_message.size();
+}

--- a/tests/XrdClCurl/curl-test.sh
+++ b/tests/XrdClCurl/curl-test.sh
@@ -161,6 +161,48 @@ if [ "$HTTP_CODE" -ne 404 ]; then
   exit 1
 fi
 
+echo "Running $TEST_NAME - error string propagation"
+
+# End-to-end check for https://github.com/PelicanPlatform/xrdcl-pelican/issues/117
+# (see reference/error-string-propagation.md).  The origin OSS fails to open
+# /test/propagate_error.txt and, on XRootD >= 6, hands back a unique marker via
+# getErrMsg().  That string must travel origin XrdHttp -> XrdClCurl (cache) ->
+# cache XrdHttp and appear in the error body the cache returns to *this* client.
+# The marker is kept in sync with tests/XrdClCurlCommon/XrdOssSlowOpen.cc.
+PROPAGATE_MARKER="XRDCLCURL-ORIGIN-ERROR-MARKER-7b3f2a91"
+PROPAGATE_OUT="$BINARY_DIR/tests/$TEST_NAME/propagate_error.out"
+PROPAGATE_ORIGIN_OUT="$BINARY_DIR/tests/$TEST_NAME/propagate_error.origin.out"
+
+# Whether the origin can surface a detailed error string at all depends on the
+# running XRootD: the OSS getErrMsg()/XERT machinery only exists in v6+.  Rather
+# than parse a version string (the Server header may omit it), probe the origin
+# directly: if its error body carries the marker, the same runtime must also
+# forward it through the cache; if not, there is nothing to propagate.
+curl --output "$PROPAGATE_ORIGIN_OUT" --cacert "$X509_CA_FILE" -s -L -H "@$HEADER_FILE" "$ORIGIN_URL/test/propagate_error.txt" 2>>"$BINARY_DIR/tests/$TEST_NAME/client.log"
+
+HTTP_CODE=$(curl --output "$PROPAGATE_OUT" --cacert "$X509_CA_FILE" -s -L --write-out '%{http_code}' -H "@$HEADER_FILE" "$CACHE_URL/test/propagate_error.txt" 2>>"$BINARY_DIR/tests/$TEST_NAME/client.log")
+
+# Regardless of version, the open failure must surface as a clean error response
+# (not a truncated "200 OK" produced after the cache has already committed).
+if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" -lt 400 ]; then
+  cat "$BINARY_DIR/tests/$TEST_NAME/cache.log"
+  echo "Expected an HTTP error for propagate_error.txt; got $HTTP_CODE with body: $(cat "$PROPAGATE_OUT" 2>/dev/null)"
+  exit 1
+fi
+
+if grep -q "$PROPAGATE_MARKER" "$PROPAGATE_ORIGIN_OUT"; then
+  if ! grep -q "$PROPAGATE_MARKER" "$PROPAGATE_OUT"; then
+    cat "$BINARY_DIR/tests/$TEST_NAME/cache.log"
+    echo "Origin emitted the error marker but it did NOT propagate into the cache's HTTP response (code $HTTP_CODE)."
+    echo "Expected to find marker '$PROPAGATE_MARKER'; cache body was: $(cat "$PROPAGATE_OUT" 2>/dev/null)"
+    exit 1
+  fi
+  echo "Origin error string propagated end-to-end into the cache's HTTP response (code $HTTP_CODE)."
+else
+  echo "Origin did not surface a detailed error string (XRootD < 6 / no XERT); skipping marker assertion."
+  echo "Cache returned a clean error ($HTTP_CODE) with body: $(cat "$PROPAGATE_OUT" 2>/dev/null)"
+fi
+
 echo "Running $TEST_NAME - download directory"
 
 HTTP_CODE=$(curl --output "$BINARY_DIR/tests/$TEST_NAME/directory.out" --cacert "$X509_CA_FILE" -v -L --write-out '%{http_code}' "$CACHE_URL/test-public/subdir" 2>> "$BINARY_DIR/tests/$TEST_NAME/client.log")

--- a/tests/XrdClCurlCommon/XrdOssSlowOpen.cc
+++ b/tests/XrdClCurlCommon/XrdOssSlowOpen.cc
@@ -41,6 +41,21 @@ namespace {
 static std::atomic<int> g_retry_read_counter{0};
 static std::atomic<int> g_retry_open_counter{0};
 
+// Error-string propagation injection (see reference/error-string-propagation.md
+// and tests/XrdClCurl/curl-test.sh).  Opening this path always fails; on XRootD
+// >= 6 the OSS hands the detailed reason back through getErrMsg() so it travels
+// origin XrdHttp -> XrdClCurl (cache) -> cache XrdHttp and must appear verbatim
+// in the HTTP error the cache returns to its client.  Keep kOriginErrorMarker in
+// sync with the marker grepped for in curl-test.sh.
+static constexpr const char *kPropagateErrorPath = "/test/propagate_error.txt";
+static constexpr const char *kOriginErrorMarker =
+    "XRDCLCURL-ORIGIN-ERROR-MARKER-7b3f2a91 simulated origin open failure";
+
+// Set just before returning a failure for kPropagateErrorPath so the matching
+// getErrMsg() (which XrdOfs invokes synchronously on the same thread) can hand
+// back the marker.
+static thread_local bool t_inject_err_msg = false;
+
 class File final : public XrdOssWrapDF {
   public:
     File(std::unique_ptr<XrdOssDF> wrapDF)
@@ -70,9 +85,30 @@ class File final : public XrdOssWrapDF {
             // Open succeeds; all reads will fail.
             return 0;
         }
+        else if (m_path == kPropagateErrorPath) {
+            // Open always fails (both Stat and Open fail for this path, so the
+            // origin returns a clean error response with a body before any 200,
+            // and the cache surfaces a clean error rather than a truncated
+            // transfer).  On XRootD >= 6 the marker is surfaced via getErrMsg().
+            m_inject_err_msg = true;
+            t_inject_err_msg = true;
+            return -EIO;
+        }
 
         return wrapDF.Open(path, Oflag, Mode, env);
     }
+
+#ifdef HAVE_XROOTD_OSS_GETERRMSG
+    // XRootD >= 6: hand the detailed error string back to XrdOfs so it can be
+    // forwarded into the HTTP error response.
+    virtual bool getErrMsg(std::string &eText) override {
+        if (m_inject_err_msg) {
+            eText = kOriginErrorMarker;
+            return true;
+        }
+        return wrapDF.getErrMsg(eText);
+    }
+#endif
 
     virtual ssize_t Read(void *buffer, off_t offset, size_t size) override {
         if (m_path == "/test/stall_read.txt") {
@@ -134,6 +170,7 @@ class File final : public XrdOssWrapDF {
   private:
     std::unique_ptr<XrdOssDF> m_wrapped;
     std::string m_path;
+    bool m_inject_err_msg{false};
 };
 
 class FileSystem final : public XrdOssWrapper {
@@ -180,9 +217,34 @@ class FileSystem final : public XrdOssWrapper {
                 buff->st_nlink = 1;
             }
             return 0;
+        } else if (spath == kPropagateErrorPath) {
+            // Fail the stat as well so the cache treats this as a clean open
+            // failure (matching a missing object) rather than committing to a
+            // 200 response and then truncating.
+            t_inject_err_msg = true;
+            return -EIO;
         }
         return wrapPI.Stat(path, buff, opts, env);
     }
+
+#ifdef HAVE_XROOTD_OSS_GETERRMSG
+    // Advertise extended-error-text support so XrdOfs consults getErrMsg() and
+    // forwards our detailed error string into the HTTP error response.
+    virtual uint64_t Features() override {
+        return wrapPI.Features() | XRDOSS_HASXERT;
+    }
+
+    // XRootD >= 6: filesystem-level counterpart of File::getErrMsg(), used when
+    // the failure is reported at Stat() time.
+    virtual bool getErrMsg(std::string &eText) override {
+        if (t_inject_err_msg) {
+            t_inject_err_msg = false;
+            eText = kOriginErrorMarker;
+            return true;
+        }
+        return wrapPI.getErrMsg(eText);
+    }
+#endif
 
   private:
     std::unique_ptr<XrdOss> m_oss;


### PR DESCRIPTION
- Do not feed libcurl error codes to XrdCl; instead, use best-fit POSIX errno.
- Use XRootD 6's new error message API to pass along the actual libcurl error message.

Includes test coverage.

Fixes #117