### PR TITLE
Pass Cache-Control / ETag through the cache for mutable objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,25 @@ int main(void) {return 0;}"
 HAVE_XROOTD_OSS_GETERRMSG)
 
 #
+# XRootD 6 added a query-code-aware File::Fcntl overload (FilePlugIn::Fcntl with a
+# QueryCode argument) plus the QueryCode::FInfo / FSInfo codes.  XrdPfc uses these
+# (via XrdPosixExtra::Fctl/FSctl) to pull Cache-Control/ETag info through the cache
+# for mutable objects.  Earlier releases lack the overload and the codes, so any
+# reference to them fails to compile.  See tests/.../curl-test.sh ETag test.
+#
+CHECK_SOURCE_COMPILES(CXX
+"#include <XrdCl/XrdClPlugInInterface.hh>
+#include <XrdCl/XrdClFileSystem.hh>
+class TestFile final : public XrdCl::FilePlugIn {
+public:
+    virtual XrdCl::XRootDStatus Fcntl(XrdCl::QueryCode::Code, const XrdCl::Buffer&,
+                                      XrdCl::ResponseHandler*, time_t) override
+        {return XrdCl::XRootDStatus();}
+};
+int main(void) {return (int)XrdCl::QueryCode::FInfo + (int)XrdCl::QueryCode::FSInfo;}"
+HAVE_XRDCL_FCNTL_QUERYCODE)
+
+#
 # Apply the XRootD feature-detection macros globally.
 #
 if (HAVE_XPROTOCOL_TIMEREXPIRED)
@@ -76,6 +95,9 @@ if (HAVE_XRDCL_IFACE6)
 endif()
 if (HAVE_XROOTD_OSS_GETERRMSG)
   add_compile_definitions(HAVE_XROOTD_OSS_GETERRMSG)
+endif()
+if (HAVE_XRDCL_FCNTL_QUERYCODE)
+  add_compile_definitions(HAVE_XRDCL_FCNTL_QUERYCODE)
 endif()
 
 # Upstream XRootD merged the XrdClCurl and XrdClS3 plugins into its own tree

--- a/src/XrdClCurl/XrdClCurlFile.cc
+++ b/src/XrdClCurl/XrdClCurlFile.cc
@@ -706,6 +706,49 @@ File::Fcntl(const XrdCl::Buffer &arg, XrdCl::ResponseHandler *handler,
     return XrdCl::XRootDStatus();
 }
 
+#ifdef HAVE_XRDCL_FCNTL_QUERYCODE
+XrdCl::XRootDStatus
+File::Fcntl(XrdCl::QueryCode::Code queryCode, const XrdCl::Buffer &arg,
+            XrdCl::ResponseHandler *handler, timeout_t timeout)
+{
+    if (!m_is_opened) {
+        m_logger->Error(kLogXrdClCurl, "Cannot run fcntl.  URL isn't open");
+        return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
+    }
+
+    // XrdPfc asks for the object's Cache-Control / ETag information so it can
+    // manage mutable objects.  The sub-command is carried in the argument
+    // buffer; only "head" is supported.  Because some origins (e.g. XRootD's
+    // XrdHttp) only emit the ETag on a HEAD response -- not on GET or PROPFIND,
+    // which is how the object was opened/cached -- issue a fresh HEAD here
+    // rather than relying on cached open properties.
+    if (queryCode == XrdCl::QueryCode::FInfo) {
+        std::string command = arg.ToString();
+        if (command != "head") {
+            m_logger->Error(kLogXrdClCurl, "Unsupported FInfo sub-command '%s'", command.c_str());
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidArgs, EINVAL, "Unsupported FInfo sub-command");
+        }
+        auto ts = GetHeaderTimeout(timeout);
+        std::unique_ptr<XrdClCurl::CurlQueryOp> queryOp(
+            new XrdClCurl::CurlQueryOp(
+                handler, m_url, ts, m_logger, SendResponseInfo(), GetConnCallout(),
+                XrdCl::QueryCode::FInfo, m_header_callout.load(std::memory_order_acquire)
+            )
+        );
+        try {
+            m_queue->Produce(std::move(queryOp));
+        } catch (...) {
+            m_logger->Warning(kLogXrdClCurl, "Failed to add FInfo query operation to queue");
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errOSError);
+        }
+        return XrdCl::XRootDStatus();
+    }
+
+    m_logger->Error(kLogXrdClCurl, "Unsupported query code %d in Fcntl", static_cast<int>(queryCode));
+    return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errNotSupported, ENOTSUP, "Unsupported query code");
+}
+#endif
+
 XrdCl::XRootDStatus
 File::Read(uint64_t                offset,
            uint32_t                size,

--- a/src/XrdClCurl/XrdClCurlFile.hh
+++ b/src/XrdClCurl/XrdClCurlFile.hh
@@ -25,6 +25,7 @@
 #include "XrdClCurlHeaderCallout.hh"
 
 #include <XrdCl/XrdClFile.hh>
+#include <XrdCl/XrdClFileSystem.hh>
 #include <XrdCl/XrdClPlugInInterface.hh>
 
 #include <atomic>
@@ -86,6 +87,16 @@ public:
     virtual XrdCl::XRootDStatus Fcntl(const XrdCl::Buffer    &arg,
                                     XrdCl::ResponseHandler *handler,
                                     timeout_t               timeout) override;
+
+#ifdef HAVE_XRDCL_FCNTL_QUERYCODE
+    // XRootD 6 query-code-aware Fcntl.  XrdPfc invokes this with
+    // QueryCode::FInfo and arg "head" to retrieve the object's Cache-Control /
+    // ETag information so it can manage mutable objects (see XrdClCurlFile.cc).
+    virtual XrdCl::XRootDStatus Fcntl(XrdCl::QueryCode::Code   queryCode,
+                                    const XrdCl::Buffer    &arg,
+                                    XrdCl::ResponseHandler *handler,
+                                    timeout_t               timeout) override;
+#endif
 
     virtual XrdCl::XRootDStatus Read(uint64_t                offset,
                                     uint32_t                size,

--- a/src/XrdClCurl/XrdClCurlFilesystem.cc
+++ b/src/XrdClCurl/XrdClCurlFilesystem.cc
@@ -218,6 +218,43 @@ XrdCl::XRootDStatus Filesystem::Query(XrdCl::QueryCode::Code  queryCode,
             return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errOSError);
         }
     }
+#ifdef HAVE_XRDCL_FCNTL_QUERYCODE
+    else if (queryCode == XrdCl::QueryCode::FSInfo)
+    {
+        // XrdPfc revalidates a (possibly mutable) cached object by fetching the
+        // origin's current ETag.  The sub-command is carried as a 'code' URL
+        // parameter (see XrdPfc::Cache::Prepare); only "head" is supported.
+        auto full_url = GetCurrentURL(arg.ToString());
+        std::string sub_code;
+        XrdCl::URL parsed;
+        if (parsed.FromString(full_url)) {
+            auto iter = parsed.GetParams().find("code");
+            if (iter != parsed.GetParams().end()) {
+                sub_code = iter->second;
+            }
+        }
+        if (sub_code != "head") {
+            m_logger->Error(kLogXrdClCurl, "Unsupported FSInfo sub-command '%s'", sub_code.c_str());
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidArgs, EINVAL, "Unsupported FSInfo sub-command");
+        }
+        m_logger->Debug(kLogXrdClCurl, "XrdClCurl::Filesystem::Query FSInfo url %s", full_url.c_str());
+        std::unique_ptr<CurlQueryOp> queryOp(
+            new CurlQueryOp(
+                handler, full_url, ts, m_logger, SendResponseInfo(),
+                GetConnCallout(), queryCode, m_header_callout.load(std::memory_order_acquire)
+            )
+        );
+        try
+        {
+            m_queue->Produce(std::move(queryOp));
+        }
+        catch (...)
+        {
+            m_logger->Warning(kLogXrdClCurl, "Failed to add FSInfo query operation to queue");
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errOSError);
+        }
+    }
+#endif
     else
     {
         return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errNotImplemented);

--- a/src/XrdClCurl/XrdClCurlOpQuery.cc
+++ b/src/XrdClCurl/XrdClCurlOpQuery.cc
@@ -23,16 +23,78 @@
 #include <XrdCl/XrdClFileSystem.hh>
 #include <XrdCl/XrdClLog.hh>
 
+#include <nlohmann/json.hpp>
+
+#include <cctype>
 #include <cerrno>
 
 using namespace XrdClCurl;
+
+#ifdef HAVE_XRDCL_FCNTL_QUERYCODE
+namespace {
+
+// Build the Cache-Control / ETag information document XrdPfc stores to manage
+// mutable objects.  May contain "ETag", "max-age" (freshness seconds), and
+// "revalidate" (true for must-revalidate / no-cache).  Keep in sync with the
+// fields consumed by XrdPfc::Cache::Prepare.
+std::string BuildCacheControlJson(const std::string &etag, const std::string &cache_control)
+{
+    nlohmann::json info;
+    if (!etag.empty()) {
+        info["ETag"] = etag;
+    }
+    if (!cache_control.empty()) {
+        if (cache_control.find("must-revalidate") != std::string::npos ||
+            cache_control.find("no-cache") != std::string::npos) {
+            info["revalidate"] = true;
+        }
+        auto fm = cache_control.find("max-age=");
+        if (fm != std::string::npos) {
+            fm += 8; // length of "max-age="
+            auto end = fm;
+            while (end < cache_control.length() &&
+                   std::isdigit(static_cast<unsigned char>(cache_control[end]))) {
+                end++;
+            }
+            if (end > fm) {
+                try {
+                    info["max-age"] = std::stol(cache_control.substr(fm, end - fm));
+                } catch (const std::exception &) {
+                    // Unparseable max-age: leave freshness unknown.
+                }
+            }
+        }
+    }
+    return info.dump();
+}
+
+} // namespace
+#endif // HAVE_XRDCL_FCNTL_QUERYCODE
 
 void CurlQueryOp::Success()
 {
     SetDone(false);
     m_logger->Debug(kLogXrdClCurl, "CurlQueryOp::Success");
 
-    if (m_queryCode == XrdCl::QueryCode::XAttr) {
+#ifdef HAVE_XRDCL_FCNTL_QUERYCODE
+    if (m_queryCode == XrdCl::QueryCode::FInfo) {
+        // XrdPfc's FInfo "head" query stores the object's Cache-Control / ETag.
+        auto respBuff = new XrdCl::Buffer();
+        respBuff->FromString(BuildCacheControlJson(m_headers.GetETag(), m_headers.GetCacheControl()));
+        auto obj = new XrdCl::AnyObject();
+        obj->Set(respBuff);
+        m_handler->HandleResponse(new XrdCl::XRootDStatus(), obj);
+        m_handler = nullptr;
+        return;
+    }
+#endif
+
+    bool returns_etag = (m_queryCode == XrdCl::QueryCode::XAttr);
+#ifdef HAVE_XRDCL_FCNTL_QUERYCODE
+    // XrdPfc's FSInfo "head" revalidation query expects the bare current ETag.
+    returns_etag = returns_etag || (m_queryCode == XrdCl::QueryCode::FSInfo);
+#endif
+    if (returns_etag) {
         XrdCl::Buffer *qInfo = new XrdCl::Buffer();
         qInfo->FromString(m_headers.GetETag());
         auto obj = new XrdCl::AnyObject();

--- a/src/XrdClCurl/XrdClCurlOpStat.cc
+++ b/src/XrdClCurl/XrdClCurlOpStat.cc
@@ -55,6 +55,12 @@ CurlStatOp::Redirect(std::string &target)
     if (result == CurlOperation::RedirectAction::Fail) {
         return result;
     }
+    if (m_force_head) {
+        // Keep using a plain HEAD across redirects.
+        m_is_propfind = false;
+        curl_easy_setopt(m_curl.get(), CURLOPT_NOBODY, 1L);
+        return CurlOperation::RedirectAction::Reinvoke;
+    }
     auto &instance = VerbsCache::Instance();
     auto verbs = instance.Get(target);
     if (verbs.IsSet(VerbsCache::HttpVerb::kUnset)) {
@@ -80,6 +86,12 @@ CurlStatOp::Setup(CURL *curl, CurlWorker &worker)
     if (!CurlOperation::Setup(curl, worker)) return false;
     curl_easy_setopt(m_curl.get(), CURLOPT_WRITEFUNCTION, CurlStatOp::WriteCallback);
     curl_easy_setopt(m_curl.get(), CURLOPT_WRITEDATA, this);
+
+    if (m_force_head) {
+        m_is_propfind = false;
+        curl_easy_setopt(m_curl.get(), CURLOPT_NOBODY, 1L);
+        return true;
+    }
 
     auto &instance = VerbsCache::Instance();
     auto verbs = instance.Get(m_url);
@@ -194,6 +206,9 @@ CurlStatOp::GetStatInfo() {
 
 bool CurlStatOp::RequiresOptions() const
 {
+    if (m_force_head) {
+        return false;
+    }
     auto &instance = VerbsCache::Instance();
     auto verbs = instance.Get(m_url);
     return verbs.IsSet(VerbsCache::HttpVerb::kUnset);

--- a/src/XrdClCurl/XrdClCurlOps.hh
+++ b/src/XrdClCurl/XrdClCurlOps.hh
@@ -510,7 +510,15 @@ public:
 
     virtual HttpVerb GetVerb() const override {return m_is_propfind ? HttpVerb::PROPFIND : HttpVerb::HEAD;}
 
+    // Force the operation to use a plain HEAD request instead of negotiating
+    // PROPFIND via OPTIONS.  Needed when the response headers themselves are the
+    // payload of interest (e.g. the ETag, which some origins only emit on HEAD).
+    void SetForceHead(bool force) {m_force_head = force;}
+
 protected:
+    // Whether the stat must use a plain HEAD (no PROPFIND / OPTIONS negotiation).
+    bool m_force_head{false};
+
     // Mark the operation as a success and, as requested, return the stat info back
     // to the object handler.
     //
@@ -642,6 +650,9 @@ public:
     CurlStatOp(handler, url, timeout, log, response_info, callout, header_callout),
     m_queryCode(queryCode)
     {
+        // Cache-control queries return response headers (notably the ETag, which
+        // some origins only emit on HEAD), so always use a plain HEAD.
+        SetForceHead(true);
     }
 
     virtual ~CurlQueryOp() {}

--- a/tests/XrdClCurl/CMakeLists.txt
+++ b/tests/XrdClCurl/CMakeLists.txt
@@ -96,13 +96,23 @@ target_include_directories(xrdscitokens-create-token
 ######################################
 # Integration tests.
 ######################################
+
+# The cache-control / ETag pass-through (and its config directives pfc.httpcc and
+# http.staticheader) only exist on XRootD 6; gate the relevant config and test on
+# the same feature the plugin was built with.
+if (HAVE_XRDCL_FCNTL_QUERYCODE)
+  set(XRDCL_CACHE_CONTROL_TEST 1)
+else()
+  set(XRDCL_CACHE_CONTROL_TEST 0)
+endif()
+
 add_test(NAME XrdClCurl::curl::setup
   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/curl-setup.sh" curl)
 
 set_tests_properties( XrdClCurl::curl::setup
   PROPERTIES
     FIXTURES_SETUP XrdClCurl::curl
-    ENVIRONMENT "OPENSSL_BIN=${OPENSSL_BIN};BINARY_DIR=${CMAKE_BINARY_DIR};SOURCE_DIR=${CMAKE_SOURCE_DIR};XROOTD_BINDIR=${XRootD_BIN_DIR};XROOTD_LIBDIR=${XRootD_LIB_DIR}"
+    ENVIRONMENT "OPENSSL_BIN=${OPENSSL_BIN};BINARY_DIR=${CMAKE_BINARY_DIR};SOURCE_DIR=${CMAKE_SOURCE_DIR};XROOTD_BINDIR=${XRootD_BIN_DIR};XROOTD_LIBDIR=${XRootD_LIB_DIR};XRDCL_CACHE_CONTROL=${XRDCL_CACHE_CONTROL_TEST}"
 )
 
 add_test( NAME XrdClCurl::curl::teardown
@@ -124,6 +134,6 @@ list( APPEND CURL_TEST_LOGS ${CMAKE_CURRENT_BINARY_DIR}/tests/curl/client.log )
 set_tests_properties( XrdClCurl::curl::test
   PROPERTIES
     FIXTURES_REQUIRED XrdClCurl::curl
-    ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR};XROOTD_BINDIR=${XRootD_DATA_DIR}/../bin;XROOTD_LIBDIR=${XRootD_LIB_DIR}"
+    ENVIRONMENT "BINARY_DIR=${CMAKE_BINARY_DIR};XROOTD_BINDIR=${XRootD_DATA_DIR}/../bin;XROOTD_LIBDIR=${XRootD_LIB_DIR};XRDCL_CACHE_CONTROL=${XRDCL_CACHE_CONTROL_TEST}"
     ATTACHED_FILES_ON_FAIL "${CURL_TEST_LOGS}"
 )

--- a/tests/XrdClCurl/curl-setup.sh
+++ b/tests/XrdClCurl/curl-setup.sh
@@ -213,6 +213,11 @@ sec.protbind * none
 
 http.header2cgi Authorization authz
 
+$( [ "${XRDCL_CACHE_CONTROL:-0}" = "1" ] && printf '%s\n' \
+  "# Emit a Cache-Control header so the cache treats objects as mutable and" \
+  "# revalidates them via the ETag (cache-control pass-through; XRootD 6 only)." \
+  'http.staticheader Cache-Control "max-age=1, must-revalidate"' )
+
 ofs.osslib ++ libXrdOssStats.so
 all.adminpath $XROOTD_RUNDIR/origin
 all.pidpath $XROOTD_RUNDIR/origin
@@ -294,6 +299,10 @@ pfc.prefetch 0
 pfc.writequeue 16 4
 pfc.ram 4g
 pfc.diskusage 0.90 0.95 purgeinterval 300s
+$( [ "${XRDCL_CACHE_CONTROL:-0}" = "1" ] && printf '%s\n' \
+  "# Enable HTTP cache-control handling so the cache pulls ETag / Cache-Control" \
+  "# through the plugin and revalidates mutable objects (XRootD 6 only)." \
+  "pfc.httpcc on" )
 
 xrootd.fslib ++ throttle
 

--- a/tests/XrdClCurl/curl-test.sh
+++ b/tests/XrdClCurl/curl-test.sh
@@ -203,6 +203,47 @@ else
   echo "Cache returned a clean error ($HTTP_CODE) with body: $(cat "$PROPAGATE_OUT" 2>/dev/null)"
 fi
 
+# Cache-control / ETag pass-through for mutable objects (see PR #68 and
+# reference/xrootd's XrdPfc httpcc support).  Only valid on XRootD 6 where the
+# plugin implements the FInfo/FSInfo query codes and the cache config enabled
+# pfc.httpcc + http.staticheader (XRDCL_CACHE_CONTROL set from CMake).
+if [ "${XRDCL_CACHE_CONTROL:-0}" = "1" ]; then
+  echo "Running $TEST_NAME - cache-control ETag pass-through"
+
+  CC_FILE="$BINARY_DIR/tests/$TEST_NAME/export/test/cc_mutable.txt"
+  CC_URL="$CACHE_URL/test/cc_mutable.txt"
+
+  # Start from a fresh inode so the ETag is well-defined even if a previous run
+  # left a file (XrdHttp derives the ETag from the inode).
+  rm -f "$CC_FILE"
+  printf 'cache-control-v1' > "$CC_FILE"
+  CC_V1=$(curl -s --cacert "$X509_CA_FILE" -H "@$HEADER_FILE" "$CC_URL" 2>>"$BINARY_DIR/tests/$TEST_NAME/client.log")
+  if [ "$CC_V1" != "cache-control-v1" ]; then
+    cat "$BINARY_DIR/tests/$TEST_NAME/cache.log"
+    echo "Initial cached fetch returned '$CC_V1', expected 'cache-control-v1'"
+    exit 1
+  fi
+
+  # Replace the object so its ETag changes.  XrdHttp derives the ETag from the
+  # inode, so the file must be recreated (not overwritten in place) to get a new
+  # ETag.  Sleep past max-age so the cached copy is also considered stale.
+  rm -f "$CC_FILE"
+  sleep 1
+  printf 'cache-control-v2-updated' > "$CC_FILE"
+  sleep 2
+
+  CC_V2=$(curl -s --cacert "$X509_CA_FILE" -H "@$HEADER_FILE" "$CC_URL" 2>>"$BINARY_DIR/tests/$TEST_NAME/client.log")
+  if [ "$CC_V2" != "cache-control-v2-updated" ]; then
+    cat "$BINARY_DIR/tests/$TEST_NAME/cache.log"
+    echo "ETag revalidation failed: after the origin object changed, the cache served"
+    echo "'$CC_V2' but expected 'cache-control-v2-updated' (stale content was not refreshed)."
+    exit 1
+  fi
+  echo "Cache-control ETag pass-through works: an updated ETag regenerated the cache."
+else
+  echo "Skipping cache-control ETag test (XRootD < 6 / feature unavailable)."
+fi
+
 echo "Running $TEST_NAME - download directory"
 
 HTTP_CODE=$(curl --output "$BINARY_DIR/tests/$TEST_NAME/directory.out" --cacert "$X509_CA_FILE" -v -L --write-out '%{http_code}' "$CACHE_URL/test-public/subdir" 2>> "$BINARY_DIR/tests/$TEST_NAME/client.log")


### PR DESCRIPTION
Logical equivalent of the long-pending PR #68, reworked for the cache-control mechanism that landed in XRootD 6.  PR #68 relied on custom XrdCl query codes from an unmerged xrootd branch; XRootD 6 instead added standard QueryCode::FInfo / FSInfo (driven by XrdPfc via XrdPosixExtra::Fctl/FSctl, gated by "pfc.httpcc").

This implements the plugin side of that contract so a cache can manage mutable objects:
  - File::Fcntl(QueryCode::FInfo, "head"): returns a JSON document {ETag, max-age, revalidate} that XrdPfc stores as the pfc.cache-control xattr when first caching the object.
  - Filesystem::Query(QueryCode::FSInfo, <url>?code=head): returns the origin's current ETag so XrdPfc can revalidate a cached copy and re-fetch on mismatch.

Both paths issue a forced HEAD (new CurlStatOp::SetForceHead) because some origins -- notably XRootD's own XrdHttp -- only emit the ETag on HEAD, not on the GET/PROPFIND used to open and cache the object.  Everything new is guarded by a HAVE_XRDCL_FCNTL_QUERYCODE feature check (the Fcntl-with-QueryCode overload and the FInfo/FSInfo codes only exist on XRootD 6); XRootD 5 builds keep the legacy XAttr path unchanged.

Integration test (tests/XrdClCurl/curl-test.sh, "cache-control ETag pass-through"): with the origin emitting Cache-Control via http.staticheader and the cache running pfc.httpcc, it caches an object, replaces it at the origin so the ETag changes, and asserts the cache serves the updated content.  The test and its v6-only config directives are gated on XRDCL_CACHE_CONTROL (set from HAVE_XRDCL_FCNTL_QUERYCODE) so the XRootD 5 fixture is unaffected.

Verified end-to-end on a live XRootD 6 build; the full curl integration suite and all unit tests pass.